### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -534,6 +534,13 @@ export default class ObjectUtils {
         }
 
         const fields = field.split('.');
+        const blockedFields = new Set(['__proto__', 'prototype', 'constructor']);
+
+        if (fields.some((part) => !part || blockedFields.has(part))) {
+            // guard against prototype pollution and malformed paths
+            return;
+        }
+
         let obj = data;
 
         for (let i = 0, len = fields.length; i < len; ++i) {


### PR DESCRIPTION
Potential fix for [https://github.com/Mantle-UI/mantle-ui/security/code-scanning/2](https://github.com/Mantle-UI/mantle-ui/security/code-scanning/2)

To fix this safely without changing intended functionality, add key-path validation inside `mutateFieldData` and reject dangerous path segments before any read/write on `obj[fields[i]]`. The best minimal fix is to block segments `__proto__`, `prototype`, and `constructor` (and optionally empty segments from malformed paths), then proceed as before.

In `components/lib/utils/ObjectUtils.js`, update `mutateFieldData` (around lines 536–551) to:

- split path as today,
- define a small denylist check for path segments,
- short-circuit (`return`) if any segment is unsafe,
- keep existing deep-creation/assignment behavior for valid paths.

No imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
