### PR TITLE
Potential fix for code scanning alert no. 1: Unvalidated dynamic method call

### DIFF
--- a/pages/api/data/customers.js
+++ b/pages/api/data/customers.js
@@ -147,12 +147,13 @@ const filters = {
 
 function filter(value, field, filterValue, filterMatchMode) {
     let filteredItems = [];
+    const matcher = Object.prototype.hasOwnProperty.call(filters, filterMatchMode) ? filters[filterMatchMode] : null;
 
     if (value) {
         for (let item of value) {
             let fieldValue = resolveFieldData(item, field);
 
-            if (filters[filterMatchMode](fieldValue, filterValue)) {
+            if (typeof matcher === 'function' && matcher(fieldValue, filterValue)) {
                 filteredItems.push(item);
             }
         }

--- a/pages/api/data/customers.js
+++ b/pages/api/data/customers.js
@@ -145,9 +145,11 @@ const filters = {
     }
 };
 
+const filterMatchers = new Map(Object.entries(filters));
+
 function filter(value, field, filterValue, filterMatchMode) {
     let filteredItems = [];
-    const matcher = Object.prototype.hasOwnProperty.call(filters, filterMatchMode) ? filters[filterMatchMode] : null;
+    const matcher = filterMatchers.has(filterMatchMode) ? filterMatchers.get(filterMatchMode) : null;
 
     if (value) {
         for (let item of value) {


### PR DESCRIPTION
Potential fix for [https://github.com/Mantle-UI/mantle-ui/security/code-scanning/1](https://github.com/Mantle-UI/mantle-ui/security/code-scanning/1)

General fix: validate the dynamic key before invoking any method. Specifically, ensure the key is an own property of the `filters` map and the resolved value is a function. If not valid, treat it as non-match (or skip), avoiding exceptions and prototype-chain dispatch.

Best minimal fix in `pages/api/data/customers.js` is inside `filter(...)` near line 155:
1. Resolve the candidate matcher once: `const matcher = Object.prototype.hasOwnProperty.call(filters, filterMatchMode) ? filters[filterMatchMode] : null;`
2. Check `typeof matcher === 'function'` before calling.
3. Only invoke matcher when valid; otherwise do nothing for that item (preserves behavior of “not matched” without throwing).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
