### PR TITLE
chore: Enable manual dispatch for API documentation workflow

### DIFF
--- a/.github/workflows/generate_api_doc.yml
+++ b/.github/workflows/generate_api_doc.yml
@@ -1,6 +1,7 @@
 name: Generate API DOC
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
     paths:
@@ -13,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'Mantle-UI/mantle-ui' && github.ref == 'refs/heads/main'
+    if: github.repository == 'Mantle-UI/mantle-ui' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Allows developers to regenerate the API documentation on demand via the GitHub Actions UI, providing greater flexibility for updates.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.
