### PR TITLE
Add manual release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,5 +49,3 @@ jobs:
       - name: Publish to npm
         working-directory: dist
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,29 @@ jobs:
   release:
     if: github.repository == 'Mantle-UI/mantle-ui' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
+      - name: Check release allowlist
+        env:
+          ACTOR: ${{ github.actor }}
+          ALLOWED_RELEASE_ACTORS: ${{ vars.RELEASE_ALLOWED_ACTORS }}
+        run: |
+          if [ -z "$ALLOWED_RELEASE_ACTORS" ]; then
+            echo "::error::Repository variable RELEASE_ALLOWED_ACTORS is not configured."
+            exit 1
+          fi
+
+          normalized_list="$(printf '%s' "$ALLOWED_RELEASE_ACTORS" | tr ',;' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d')"
+
+          if ! printf '%s\n' "$normalized_list" | grep -Fxq "$ACTOR"; then
+            echo "::error::User '$ACTOR' is not allowed to run releases."
+            echo "Allowed actors are controlled by the RELEASE_ALLOWED_ACTORS repository variable."
+            exit 1
+          fi
+
+          echo "Release authorized for $ACTOR."
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: read
+
+jobs:
+  release:
+    if: github.repository == 'Mantle-UI/mantle-ui' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine next version and update changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node ./scripts/release.js
+
+      - name: Read release version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Commit release changes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git add CHANGELOG.md package-lock.json package.json
+          git commit -m "chore(release): v$VERSION"
+
+      - name: Create release tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: git tag "v$VERSION"
+
+      - name: Push release commit and tag
+        run: git push --follow-tags origin HEAD:main
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh release create "v$VERSION" --title "v$VERSION" --notes-file RELEASE_NOTES.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,6 +107,30 @@ These scripts perform:
   Use this when you want the extra verification gate before release work,
   especially the audit check.
 
+## Release Workflow
+
+Releases are created manually from GitHub Actions with the `Release` workflow on `main`.
+
+The workflow does not publish to npm directly. It prepares the release and creates the GitHub Release, and `.github/workflows/npm-publish.yml` publishes to npm afterwards.
+
+Before running, the workflow checks `github.actor` against the `RELEASE_ALLOWED_ACTORS` repository variable. Set that variable in repository settings as a comma-separated or newline-separated list of allowed GitHub usernames.
+The release job targets the protected `release` environment, so required reviewers and other configured deployment protection rules apply to the workflow run.
+
+Release bump detection is based on merged pull requests since the latest tag:
+
+- `breaking-change` label on the PR or any linked issue => major
+- linked issue type `feature` => minor
+- linked issue type `bug` => patch
+
+Priority is `breaking-change > feature > bug`.
+
+Linked issues are resolved from:
+
+- PR body closing references such as `Fixes #123`
+- GitHub-linked issue relationships on the pull request
+
+`bug` and `feature` labels do not affect version bumps.
+
 ## Developing the Library Against Another App
 
 If you want to test Mantle UI inside another project, build the library to

--- a/README.md
+++ b/README.md
@@ -89,10 +89,47 @@ npm exec mantleui migrate -- --dry-run
 
 If you copy the script into another project manually, keep the `.cjs` extension so it also works in projects using `"type": "module"`.
 
-## Publishing
+## Releasing
 
-Adjust the version in the `package.json` run `npm i` and if necessary and commit files.
-Then simply "Publish a Release" on GitHub and the workflow will handle publishing to NPM based on the tag `v10.x.x`
+Mantle UI uses a manual GitHub Actions release workflow. Maintainers do not edit the version by hand and do not publish to npm directly from a local machine.
+
+Start the `Release` workflow from GitHub Actions on the `main` branch. The workflow will:
+
+- inspect merged pull requests since the latest Git tag
+- resolve linked issues from both PR body references like `fixes #123` and GitHub-linked issue relationships
+- calculate the next version automatically
+- update `package.json` and `package-lock.json`
+- commit the release as `chore(release): vX.Y.Z`
+- create and push the `vX.Y.Z` tag
+- create the GitHub Release
+
+The existing npm publish workflow is triggered by that GitHub Release and publishes `@mantle-ui/react` via trusted publishing.
+
+Before the workflow does any release work, it checks `github.actor` against the `RELEASE_ALLOWED_ACTORS` repository variable. Configure that variable as a comma-separated or newline-separated list of allowed GitHub usernames.
+The release job is also attached to the protected `release` environment, so GitHub environment rules and reviewers are enforced before the job proceeds.
+
+### Release Version Rules
+
+- `breaking-change` label on the PR or on any linked issue => major release
+- linked issue type `feature` => minor release
+- linked issue type `bug` => patch release
+
+Priority is:
+
+```txt
+breaking-change > feature > bug
+```
+
+If no relevant release signal exists since the latest tag, the release workflow fails without creating a release.
+
+### PR Linking Convention
+
+To make release detection reliable, pull requests should either:
+
+- include closing references in the PR body, for example `Fixes #123`
+- or be linked to issues using GitHub's linked issue relationship
+
+The PR title does not affect version calculation.
 
 ## Contributors
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,364 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const BUMP_PRIORITY = {
+    bug: 1,
+    feature: 2,
+    'breaking-change': 3
+};
+const SECTION_ORDER = ['breaking-change', 'feature', 'bug', 'other'];
+const SECTION_TITLES = {
+    'breaking-change': 'Breaking Changes',
+    feature: 'Features',
+    bug: 'Bug Fixes',
+    other: 'Other Changes'
+};
+const CLOSING_KEYWORDS_PATTERN = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...options
+    });
+
+    if (result.status !== 0) {
+        throw new Error(result.stderr.trim() || `Command failed: ${command} ${args.join(' ')}`);
+    }
+
+    return result.stdout.trim();
+}
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, content) {
+    fs.writeFileSync(filePath, `${JSON.stringify(content, null, 4)}\n`);
+}
+
+function parseVersion(version) {
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+
+    if (!match) {
+        throw new Error(`Unsupported version format: ${version}`);
+    }
+
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3])
+    };
+}
+
+function incrementVersion(version, bump) {
+    const parsed = parseVersion(version);
+
+    if (bump === 'breaking-change') {
+        return `${parsed.major + 1}.0.0`;
+    }
+
+    if (bump === 'feature') {
+        return `${parsed.major}.${parsed.minor + 1}.0`;
+    }
+
+    return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
+}
+
+function normalizeLabels(labels) {
+    return labels
+        .map((label) => label.name.toLowerCase())
+        .filter(Boolean);
+}
+
+function extractBreakingChangeLabel(labels) {
+    return normalizeLabels(labels).includes('breaking-change');
+}
+
+function getHighestPriorityLabel(labels) {
+    return labels.reduce((highest, label) => {
+        if (!highest || BUMP_PRIORITY[label] > BUMP_PRIORITY[highest]) {
+            return label;
+        }
+
+        return highest;
+    }, null);
+}
+
+function extractClosingIssueNumbers(body) {
+    const issueNumbers = new Set();
+    const text = body || '';
+    let match;
+
+    while ((match = CLOSING_KEYWORDS_PATTERN.exec(text)) !== null) {
+        issueNumbers.add(Number(match[1]));
+    }
+
+    return [...issueNumbers];
+}
+
+function fetchMergedPullRequests(lastTagDate) {
+    const mergedSinceDate = lastTagDate.slice(0, 10);
+    const prs = JSON.parse(
+        run('gh', [
+            'pr',
+            'list',
+            '--state',
+            'merged',
+            '--base',
+            'main',
+            '--search',
+            `merged:>=${mergedSinceDate}`,
+            '--limit',
+            '200',
+            '--json',
+            'number,title,url,mergedAt,labels,body'
+        ])
+    );
+
+    return prs.filter((pr) => pr.mergedAt > lastTagDate).sort((left, right) => new Date(left.mergedAt) - new Date(right.mergedAt));
+}
+
+function fetchPullRequestLinkedIssueNumbers(repo, pullRequestNumber) {
+    const [owner, name] = repo.split('/');
+    const response = JSON.parse(
+        run('gh', [
+            'api',
+            'graphql',
+            '-f',
+            `query=query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 100) {
+        nodes {
+          number
+        }
+      }
+    }
+  }
+}`,
+            '-F',
+            `owner=${owner}`,
+            '-F',
+            `name=${name}`,
+            '-F',
+            `number=${pullRequestNumber}`
+        ])
+    );
+
+    return response.data?.repository?.pullRequest?.closingIssuesReferences?.nodes?.map((issue) => issue.number) || [];
+}
+
+function fetchIssueLabelMap(repo, issueNumbers) {
+    const issueMap = new Map();
+
+    const [owner, name] = repo.split('/');
+
+    for (const issueNumber of issueNumbers) {
+        const response = JSON.parse(
+            run('gh', [
+                'api',
+                'graphql',
+                '-f',
+                `query=query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      issueType {
+        name
+      }
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}`,
+                '-F',
+                `owner=${owner}`,
+                '-F',
+                `name=${name}`,
+                '-F',
+                `number=${issueNumber}`
+            ])
+        );
+        const issue = response.data?.repository?.issue;
+
+        if (!issue) {
+            continue;
+        }
+
+        issueMap.set(issueNumber, {
+            type: issue.issueType?.name?.toLowerCase() || null,
+            hasBreakingChange: extractBreakingChangeLabel(issue.labels?.nodes || [])
+        });
+    }
+
+    return issueMap;
+}
+
+function resolvePullRequestReleaseInfo(pr, issueMap, githubLinkedIssueNumbers) {
+    const hasPrBreakingChange = extractBreakingChangeLabel(pr.labels || []);
+    const bodyLinkedIssueNumbers = extractClosingIssueNumbers(pr.body);
+    const linkedIssueNumbers = [...new Set([...bodyLinkedIssueNumbers, ...githubLinkedIssueNumbers])];
+    const linkedIssues = linkedIssueNumbers.map((issueNumber) => issueMap.get(issueNumber)).filter(Boolean);
+    const hasIssueBreakingChange = linkedIssues.some((issue) => issue.hasBreakingChange);
+    const linkedIssueTypes = [...new Set(linkedIssues.map((issue) => issue.type).filter((type) => type === 'feature' || type === 'bug'))];
+    let effectiveLabel = null;
+
+    if (hasPrBreakingChange || hasIssueBreakingChange) {
+        effectiveLabel = 'breaking-change';
+    } else if (linkedIssueTypes.includes('feature')) {
+        effectiveLabel = 'feature';
+    } else if (linkedIssueTypes.includes('bug')) {
+        effectiveLabel = 'bug';
+    }
+
+    return {
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        mergedAt: pr.mergedAt,
+        hasPrBreakingChange,
+        bodyLinkedIssueNumbers,
+        githubLinkedIssueNumbers,
+        linkedIssueNumbers,
+        linkedIssueTypes,
+        hasIssueBreakingChange,
+        effectiveLabel
+    };
+}
+
+function detectBump(prs) {
+    const labels = prs.map((pr) => pr.effectiveLabel).filter(Boolean);
+
+    return getHighestPriorityLabel(labels);
+}
+
+function updatePackageVersion(filePath, nextVersion) {
+    const content = readJson(filePath);
+
+    content.version = nextVersion;
+
+    if (content.packages && content.packages['']) {
+        content.packages[''].version = nextVersion;
+    }
+
+    writeJson(filePath, content);
+}
+
+function formatReleaseItem(pr) {
+    const linkedIssuesSuffix = pr.linkedIssueNumbers.length ? ` (issues: ${pr.linkedIssueNumbers.map((issueNumber) => `#${issueNumber}`).join(', ')})` : '';
+
+    return `- ${pr.title} [#${pr.number}](${pr.url})${linkedIssuesSuffix}`;
+}
+
+function buildReleaseNotes(nextVersion, today, compareUrl, prs) {
+    const grouped = {
+        'breaking-change': [],
+        feature: [],
+        bug: [],
+        other: []
+    };
+
+    for (const pr of prs) {
+        grouped[pr.effectiveLabel || 'other'].push(pr);
+    }
+
+    const sections = [];
+
+    for (const key of SECTION_ORDER) {
+        if (!grouped[key].length) {
+            continue;
+        }
+
+        sections.push(`## ${SECTION_TITLES[key]}\n\n${grouped[key].map(formatReleaseItem).join('\n')}`);
+    }
+
+    return [`## [${nextVersion}](${compareUrl}) (${today})`, '', `[Full Changelog](${compareUrl})`, '', ...sections].join('\n');
+}
+
+function prependChangelogEntry(filePath, entry) {
+    const current = fs.readFileSync(filePath, 'utf8');
+    const header = '# Changelog';
+
+    if (!current.startsWith(header)) {
+        throw new Error(`${path.basename(filePath)} is missing the expected "# Changelog" header.`);
+    }
+
+    const body = current.slice(header.length).replace(/^\r?\n*/, '');
+    const next = `${header}\n\n${entry}\n\n${body.trimStart()}`;
+
+    fs.writeFileSync(filePath, `${next.trimEnd()}\n`);
+}
+
+function main() {
+    const repo = process.env.GITHUB_REPOSITORY;
+
+    if (!repo) {
+        throw new Error('GITHUB_REPOSITORY is required.');
+    }
+
+    const packageJsonPath = path.resolve('package.json');
+    const packageLockPath = path.resolve('package-lock.json');
+    const changelogPath = path.resolve('CHANGELOG.md');
+    const releaseNotesPath = path.resolve('RELEASE_NOTES.md');
+    const currentVersion = readJson(packageJsonPath).version;
+    const lastTag = run('git', ['describe', '--tags', '--abbrev=0']);
+    const lastTagDate = run('git', ['log', '-1', '--format=%cI', lastTag]);
+    const lastTaggedVersion = lastTag.replace(/^v/, '');
+
+    if (currentVersion !== lastTaggedVersion) {
+        throw new Error(`package.json version (${currentVersion}) does not match the latest tag (${lastTag}).`);
+    }
+
+    const mergedPullRequests = fetchMergedPullRequests(lastTagDate);
+
+    if (!mergedPullRequests.length) {
+        throw new Error(`No merged pull requests found after ${lastTag}.`);
+    }
+
+    const githubLinkedIssueNumbersByPr = new Map(
+        mergedPullRequests.map((pr) => [pr.number, fetchPullRequestLinkedIssueNumbers(repo, pr.number)])
+    );
+    const allIssueNumbers = [...new Set(
+        mergedPullRequests.flatMap((pr) => {
+            const bodyLinkedIssueNumbers = extractClosingIssueNumbers(pr.body);
+            const githubLinkedIssueNumbers = githubLinkedIssueNumbersByPr.get(pr.number) || [];
+
+            return [...bodyLinkedIssueNumbers, ...githubLinkedIssueNumbers];
+        })
+    )];
+    const issueMap = fetchIssueLabelMap(repo, allIssueNumbers);
+    const releasePullRequests = mergedPullRequests.map((pr) => resolvePullRequestReleaseInfo(pr, issueMap, githubLinkedIssueNumbersByPr.get(pr.number) || []));
+    const detectedBump = detectBump(releasePullRequests);
+
+    if (!detectedBump) {
+        throw new Error('No relevant release signal found since the latest tag. Use breaking-change on the PR or linked issue, or link issues with type feature or bug before creating a release.');
+    }
+
+    const nextVersion = incrementVersion(currentVersion, detectedBump);
+    const today = new Date().toISOString().slice(0, 10);
+    const compareUrl = `https://github.com/${repo}/compare/${lastTag}...v${nextVersion}`;
+    const releaseNotes = buildReleaseNotes(nextVersion, today, compareUrl, releasePullRequests);
+
+    updatePackageVersion(packageJsonPath, nextVersion);
+
+    if (fs.existsSync(packageLockPath)) {
+        updatePackageVersion(packageLockPath, nextVersion);
+    }
+
+    prependChangelogEntry(changelogPath, releaseNotes);
+    fs.writeFileSync(releaseNotesPath, `${releaseNotes}\n`);
+    console.log(`Prepared ${nextVersion} from ${releasePullRequests.length} merged pull request(s) since ${lastTag}.`);
+    console.log(`Detected bump: ${detectedBump}`);
+}
+
+try {
+    main();
+} catch (error) {
+    console.error(error.message);
+    process.exit(1);
+}


### PR DESCRIPTION
This PR adds a manual release workflow for the package.

The workflow is started manually through workflow_dispatch and prepares a GitHub Release. Publishing to npm remains handled by the existing npm-publish.yml workflow, which is triggered by the created GitHub Release.

Fixes: #37 