### PR TITLE
Update Discord invite link and consolidate community channels

### DIFF
--- a/components/doc/contribution/communicationdoc.js
+++ b/components/doc/contribution/communicationdoc.js
@@ -5,8 +5,8 @@ export function CommunicationDoc(props) {
         <DocSectionText {...props}>
             <p>
                 Join the Contributors channel on the{' '}
-                <a href="https://discord.com/invite/gzKFYnpmCY" target="_blank" rel="noopener noreferrer">
-                    PrimeLand Discord
+                <a href="https://discord.gg/BGs6EkpnDv" target="_blank" rel="noopener noreferrer">
+                    Mantle UI Discord
                 </a>{' '}
                 server to connect with MantleUI staff and fellow contributors. In this channel, you can discuss the areas you want to contribute to and receive feedback. This channel is open to everyone who'd like to contribute.
             </p>

--- a/components/doc/contribution/helpneededdoc.js
+++ b/components/doc/contribution/helpneededdoc.js
@@ -24,7 +24,7 @@ export function HelpNeededDoc(props) {
                     GitHub Discussions
                 </a>
                 , and the{' '}
-                <a href="https://discord.com/invite/gzKFYnpmCY" target="_blank" rel="noopener noreferrer">
+                <a href="https://discord.gg/BGs6EkpnDv" target="_blank" rel="noopener noreferrer">
                     Mantle UI Discord
                 </a>{' '}
                 server. Your expertise can help others solve problems and improve their experience with MantleUI.

--- a/components/landing/footersection.js
+++ b/components/landing/footersection.js
@@ -24,12 +24,7 @@ const FooterSection = () => {
                         <ul className="list-none p-0 m-0">
                             <li className="font-bold mb-5">Community</li>
                             <li className="mb-4">
-                                <a href="https://github.com/Mantle-UI/mantle-ui/discussions" className="text-secondary font-medium hover:text-primary transition-colors transition-duration-150" target="_blank" rel="noopener noreferrer">
-                                    Forum
-                                </a>
-                            </li>
-                            <li className="mb-4">
-                                <a href="https://discord.gg/gzKFYnpmCY" className="text-secondary font-medium hover:text-primary transition-colors transition-duration-150" target="_blank" rel="noopener noreferrer">
+                                <a href="https://discord.gg/BGs6EkpnDv" className="text-secondary font-medium hover:text-primary transition-colors transition-duration-150" target="_blank" rel="noopener noreferrer">
                                     Discord
                                 </a>
                             </li>
@@ -51,11 +46,6 @@ const FooterSection = () => {
                             <li className="mb-4">
                                 <a href="https://github.com/Mantle-UI/mantle-ui/blob/main/CHANGELOG.md" className="text-secondary font-medium hover:text-primary transition-colors transition-duration-150" target="_blank" rel="noopener noreferrer">
                                     Changelog
-                                </a>
-                            </li>
-                            <li className="mb-4">
-                                <a href="https://github.com/Mantle-UI/mantle-ui/discussions" className="text-secondary font-medium hover:text-primary transition-colors transition-duration-150" target="_blank" rel="noopener noreferrer">
-                                    Contact Us
                                 </a>
                             </li>
                         </ul>
@@ -87,17 +77,11 @@ const FooterSection = () => {
                 <div className="flex flex-wrap justify-content-between py-6 gap-5">
                     <span className="font-semibold text-xl">Mantle UI</span>
                     <div className="flex align-items-center">
-                        <a href="https://github.com/Mantle-UI/mantle-ui/releases" className="linkbox block w-3rem h-3rem flex align-items-center justify-content-center mr-3">
-                            <i className="pi pi-twitter" />
-                        </a>
                         <a href="https://github.com/Mantle-UI/mantle-ui" className="linkbox block w-3rem h-3rem flex align-items-center justify-content-center mr-3">
                             <i className="pi pi-github" />
                         </a>
-                        <a href="https://discord.gg/gzKFYnpmCY" className="linkbox block w-3rem h-3rem flex align-items-center justify-content-center mr-3">
+                        <a href="https://discord.gg/BGs6EkpnDv" className="linkbox block w-3rem h-3rem flex align-items-center justify-content-center mr-3">
                             <i className="pi pi-discord" />
-                        </a>
-                        <a href="https://github.com/Mantle-UI/mantle-ui/discussions" className="linkbox block w-3rem h-3rem flex align-items-center justify-content-center">
-                            <i className="pi pi-comments" />
                         </a>
                     </div>
                 </div>

--- a/components/layout/topbar.js
+++ b/components/layout/topbar.js
@@ -104,22 +104,12 @@ export default function Topbar(props) {
                     </li>
                     <li>
                         <a
-                            href="https://discord.gg/gzKFYnpmCY"
+                            href="https://discord.gg/BGs6EkpnDv"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="flex flex-shrink-0 px-link border-1 border-solid w-2rem h-2rem surface-border border-round surface-card align-items-center justify-content-center transition-all transition-duration-300 hover:border-primary"
                         >
                             <i className="pi pi-discord text-700" />
-                        </a>
-                    </li>
-                    <li>
-                        <a
-                            href="https://github.com/Mantle-UI/mantle-ui/discussions"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex flex-shrink-0 px-link border-1 border-solid w-2rem h-2rem surface-border border-round surface-card align-items-center justify-content-center transition-all transition-duration-300 hover:border-primary"
-                        >
-                            <i className="pi pi-comments text-700" />
                         </a>
                     </li>
                     <li>

--- a/pages/support/index.js
+++ b/pages/support/index.js
@@ -10,7 +10,7 @@ const SupportPage = () => {
                             Forum
                         </a>{' '}
                         and{' '}
-                        <a href="https://discord.gg/gzKFYnpmCY" className="text-primary font-medium hover:underline" target="_blank" rel="noopener noreferrer">
+                        <a href="https://discord.gg/BGs6EkpnDv" className="text-primary font-medium hover:underline" target="_blank" rel="noopener noreferrer">
                             Discord
                         </a>{' '}
                         are where the community gathers to seek support, post topics and discuss the technology. GitHub issues are available for bug reports and maintenance work, but response times are not guaranteed. If you need a dedicated support

--- a/pages/uikit/index.js
+++ b/pages/uikit/index.js
@@ -337,7 +337,7 @@ const UIKitPage = (props) => {
                                 <p className="mt-0 mb-6 p-0 line-height-3 text-lg">
                                     PrimeTek offers assistance with account management and licensing issues, with the expectation that users have the necessary technical knowledge to use our products, as we do not offer technical support or
                                     consulting. Users can seek assistance in our community via our public{' '}
-                                    <a href="https://discord.com/invite/gzKFYnpmCY" className="text-primary hover:underline font-medium">
+                                    <a href="https://discord.gg/BGs6EkpnDv" className="text-primary hover:underline font-medium">
                                         Discord
                                     </a>{' '}
                                     and{' '}


### PR DESCRIPTION
Fixes: #45 

- Replaces the old Discord invite link with a new permanent one across all documentation and landing pages.
- Removes redundant community links (Forum, Contact Us, Twitter, GitHub Discussions) from the footer and topbar to streamline communication paths and simplify user navigation.
- Corrects the Discord server name reference from "PrimeLand Discord" to "Mantle UI Discord" for accurate branding.
