### PR TITLE
#362 - Refactor PrimeReact references to Mantle UI

### DIFF
--- a/components/doc/common/codeeditor/index.js
+++ b/components/doc/common/codeeditor/index.js
@@ -59,26 +59,26 @@ export const useStackBlitz = (props) => {
 
         Object.entries(stackBlitzParameters.files).forEach(([k, v]) => (files[`${k}`] = typeof v.content === 'object' ? JSON.stringify(v.content, null, 2) : v.content));
 
-        const primereactproject = {
+        const mantleUiProject = {
             title: props.title || 'MantleUI Demo',
             template: 'node',
             description: props.embedded
                 ? "This example demonstrates how to style components with Tailwind CSS using MantleUI's unstyled property. As mentioned in the MantleUI documentation, components can be styled or have HTML attributes added using a global or inline pass through approach. In this example, we utilize the global PT approach with Tailwind CSS."
                 : '**' +
                   (props.description || '') +
-                  '**\n MantleUI is an open source UI library for React featuring a rich set of 90+ components, a theme designer, various theme alternatives such as Material, Bootstrap, Tailwind, premium templates and professional support. In addition, it integrates with PrimeBlock, which has 370+ ready to use UI blocks to build spectacular applications in no time.',
+                  '**\n MantleUI is an open source React component library with a broad set of components, multiple theming options, and support for both styled and unstyled workflows.',
             dependencies: stackBlitzParameters.dependencies,
             files
         };
 
         if (props.embedded) {
-            sdk.embedProject('embed', primereactproject, {
+            sdk.embedProject('embed', mantleUiProject, {
                 openFile: 'src/App.jsx',
                 view: 'default',
                 height: '800px'
             });
         } else {
-            sdk.openProject(primereactproject, {
+            sdk.openProject(mantleUiProject, {
                 newWindow: true,
                 openFile: [stackBlitzParameters.sourceFileName]
             });

--- a/components/doc/common/codeeditor/index.js
+++ b/components/doc/common/codeeditor/index.js
@@ -64,9 +64,7 @@ export const useStackBlitz = (props) => {
             template: 'node',
             description: props.embedded
                 ? "This example demonstrates how to style components with Tailwind CSS using MantleUI's unstyled property. As mentioned in the MantleUI documentation, components can be styled or have HTML attributes added using a global or inline pass through approach. In this example, we utilize the global PT approach with Tailwind CSS."
-                : '**' +
-                  (props.description || '') +
-                  '**\n MantleUI is an open source React component library with a broad set of components, multiple theming options, and support for both styled and unstyled workflows.',
+                : '**' + (props.description || '') + '**\n MantleUI is an open source React component library with a broad set of components, multiple theming options, and support for both styled and unstyled workflows.',
             dependencies: stackBlitzParameters.dependencies,
             files
         };

--- a/components/doc/common/codeeditor/templates.js
+++ b/components/doc/common/codeeditor/templates.js
@@ -3,8 +3,7 @@ import { services } from './services';
 
 const MantleUI = {
     version: 'latest' || pkg.version, // latest
-    description:
-        'MantleUI is an open source UI library for React featuring a rich set of 80+ components, a theme designer, various theme alternatives such as Material, Bootstrap, Tailwind, premium templates and professional support. In addition, it integrates with PrimeBlock, which has 370+ ready to use UI blocks to build spectacular applications in no time.'
+    description: 'MantleUI is an open source React component library with a broad set of components, multiple theming options, and support for both styled and unstyled workflows.'
 };
 
 const app_dependencies = pkg ? pkg.dependencies : {};
@@ -67,7 +66,7 @@ const getConfiguredDependencies = (isUnstyled, isTypeScript) => {
         react: app_dependencies.react || 'latest',
         'react-dom': app_dependencies['react-dom'] || 'latest',
         'react-transition-group': app_dependencies['react-transition-group'] || 'latest',
-        primereact: MantleUI.version || 'latest', // latest
+        '@mantle-ui/react': MantleUI.version || 'latest', // latest
         primeicons: app_dependencies.primeicons || 'latest',
         vite: 'latest',
         '@vitejs/plugin-react': 'latest',
@@ -99,7 +98,7 @@ export default {
     content: [
         './index.html',
         './src/**/*.{vue,js,ts,jsx,tsx}',
-        './node_modules/primereact/**/*.{js,ts,jsx,tsx}',
+        './node_modules/@mantle-ui/react/**/*.{js,ts,jsx,tsx}',
     ],
     theme: {
         extend: {},
@@ -235,7 +234,7 @@ import ReactDOM from 'react-dom/client';
 import 'primeicons/primeicons.css';
 import { MantleProvider } from '@mantle-ui/react/api';
 import 'primeflex/primeflex.css';
-import '@mantle-ui/react/resources/primereact.css';
+import '@mantle-ui/react/resources/mantle-ui-react.css';
 import '@mantle-ui/react/resources/themes/lara-light-indigo/theme.css';
 
 import './index.css';
@@ -261,7 +260,7 @@ const getVite = (props = {}, template = 'javascript') => {
     const isTypeScript = template === 'typescript';
     const fileExtension = isTypeScript ? 'tsx' : 'jsx';
 
-    const { code: sources, title = 'primereact_demo', description = '', dependencies: pDependencies = {} } = props;
+    const { code: sources, title = 'mantle_ui_demo', description = '', dependencies: pDependencies = {} } = props;
 
     const configuredDependencies = getConfiguredDependencies(isUnstyled, isTypeScript);
     const dependencies = { ...configuredDependencies, ...pDependencies, 'react-scripts': '5.0.1' };

--- a/components/doc/installation/context.js
+++ b/components/doc/installation/context.js
@@ -27,7 +27,7 @@ export default function MyApp({ Component, pageProps }) {
         <>
             <DocSectionText {...props}>
                 <p>
-                    Configuration is managed by the <i>MantleProvider</i> and <i>MantleContext</i> imported from <i>primereact/api</i>.
+                    Configuration is managed by the <i>MantleProvider</i> and <i>MantleContext</i> imported from <i>@mantle-ui/react/api</i>.
                 </p>
             </DocSectionText>
             <DocSectionCode code={code} hideToggleCode import hideStackBlitz />

--- a/components/doc/installation/downloaddoc.js
+++ b/components/doc/installation/downloaddoc.js
@@ -5,10 +5,10 @@ export function DownloadDoc(props) {
     const code = {
         basic: `
 // with npm
-npm install primereact
+npm install @mantle-ui/react
 
 // with yarn
-yarn add primereact
+yarn add @mantle-ui/react
         `
     };
 
@@ -16,7 +16,7 @@ yarn add primereact
         <>
             <DocSectionText {...props}>
                 <p>
-                    MantleUI is available for download at <a href="https://www.npmjs.com/package/primereact">npm</a>.
+                    Mantle UI is available on <a href="https://www.npmjs.com/package/@mantle-ui/react">npm</a>.
                 </p>
             </DocSectionText>
             <DocSectionCode code={code} hideToggleCode import hideStackBlitz />

--- a/components/doc/installation/examplesdoc.js
+++ b/components/doc/installation/examplesdoc.js
@@ -4,22 +4,9 @@ export function ExamplesDoc(props) {
     return (
         <>
             <DocSectionText {...props}>
-                <p>We've created various samples for the popular options in the React ecosystem.</p>
+                <p>Mantle UI works with the usual React application setups, including Vite and Next.js.</p>
+                <p>Framework-specific starter examples are being refreshed for the Mantle UI project and will be published in the repository as they are finalized.</p>
             </DocSectionText>
-            <div className="flex flex-wrap card justify-content-between gap-3">
-                <a href="https://github.com/primefaces/primereact-examples/tree/main/cra-basic">
-                    <img src="https://primefaces.org/cdn/primereact/images/logos/cra.svg" alt="Create React App" className="w-8rem h-8rem" />
-                </a>
-                <a href="https://github.com/primefaces/primereact-examples/tree/main/nextjs-basic">
-                    <img src="https://primefaces.org/cdn/primereact/images/logos/next-js.svg" alt="Next.JS" className="w-8rem h-8rem" />
-                </a>
-                <a href="https://github.com/primefaces/primereact-examples/tree/main/vite-basic-ts">
-                    <img src="https://primefaces.org/cdn/primereact/images/logos/vite.png" alt="Vite" className="w-8rem h-8rem" />
-                </a>
-                <a href="https://github.com/refinedev/refine/tree/master/examples/blog-refine-primereact">
-                    <img src="https://primefaces.org/cdn/primereact/images/logos/refine.svg" alt="Refine" className="w-8rem h-8rem" />
-                </a>
-            </div>
         </>
     );
 }

--- a/components/doc/installation/styleddoc.js
+++ b/components/doc/installation/styleddoc.js
@@ -13,7 +13,7 @@ import "@mantle-ui/react/resources/themes/lara-light-cyan/theme.css";
         <>
             <DocSectionText {...props}>
                 <p>
-                    Styled mode is based on pre-skinned components with opinionated themes like Material, Bootstrap or PrimeOne themes. Theme is the required css file to be imported, visit the <Link href="/theming/#themes">Themes</Link> section for
+                    Styled mode is based on pre-skinned components with opinionated themes such as Material, Bootstrap, and Lara. Theme is the required css file to be imported, visit the <Link href="/theming/#themes">Themes</Link> section for
                     the complete list of available themes to choose from.
                 </p>
                 <DocSectionCode code={code} hideToggleCode import hideStackBlitz />

--- a/components/doc/installation/styleddoc.js
+++ b/components/doc/installation/styleddoc.js
@@ -13,8 +13,8 @@ import "@mantle-ui/react/resources/themes/lara-light-cyan/theme.css";
         <>
             <DocSectionText {...props}>
                 <p>
-                    Styled mode is based on pre-skinned components with opinionated themes such as Material, Bootstrap, and Lara. Theme is the required css file to be imported, visit the <Link href="/theming/#themes">Themes</Link> section for
-                    the complete list of available themes to choose from.
+                    Styled mode is based on pre-skinned components with opinionated themes such as Material, Bootstrap, and Lara. Theme is the required css file to be imported, visit the <Link href="/theming/#themes">Themes</Link> section for the
+                    complete list of available themes to choose from.
                 </p>
                 <DocSectionCode code={code} hideToggleCode import hideStackBlitz />
             </DocSectionText>

--- a/pages/playground/index.js
+++ b/pages/playground/index.js
@@ -1,6 +1,63 @@
+import sdk from '@stackblitz/sdk';
+import { getVite } from '@/components/doc/common/codeeditor/templates';
 import Head from 'next/head';
+import { useEffect } from 'react';
 
 const PlayGround = () => {
+    useEffect(() => {
+        const { files, dependencies } = getVite(
+            {
+                title: 'Mantle UI Playground',
+                description: 'Interactive Mantle UI playground powered by Vite and StackBlitz.',
+                code: {
+                    typescript: `
+import React from 'react';
+import { Button } from '@mantle-ui/react/button';
+import { Card } from '@mantle-ui/react/card';
+import { InputText } from '@mantle-ui/react/inputtext';
+
+export default function App() {
+    return (
+        <div className="card flex flex-column gap-3">
+            <h2 className="m-0">Mantle UI Playground</h2>
+            <p className="m-0">Edit the code and experiment with Mantle UI components directly in the browser.</p>
+            <div className="flex flex-column gap-2 md:flex-row">
+                <InputText placeholder="Try typing here" />
+                <Button label="Primary action" />
+            </div>
+            <Card title="Starter card" subTitle="Vite + React + Mantle UI">
+                <p className="m-0">This starter is generated from the Mantle UI docs project instead of pointing to an old PrimeReact StackBlitz sample.</p>
+            </Card>
+        </div>
+                    `
+                }
+            },
+            'typescript'
+        );
+
+        const normalizedFiles = {};
+
+        Object.entries(files).forEach(([key, value]) => {
+            normalizedFiles[key] = typeof value.content === 'object' ? JSON.stringify(value.content, null, 2) : value.content;
+        });
+
+        sdk.embedProject(
+            'playground-embed',
+            {
+                title: 'Mantle UI Playground',
+                template: 'node',
+                description: 'Interactive Mantle UI playground powered by Vite and StackBlitz.',
+                dependencies,
+                files: normalizedFiles
+            },
+            {
+                openFile: 'src/App.tsx',
+                view: 'default',
+                height: '800px'
+            }
+        );
+    }, []);
+
     return (
         <div>
             <Head>
@@ -14,12 +71,7 @@ const PlayGround = () => {
                         <p>Experience Mantle UI right now with the interactive environment.</p>
                     </div>
                     <section className="py-4">
-                        <iframe
-                            className="w-full h-full"
-                            style={{ border: '1px solid rgba(0, 0, 0, 0.1)', borderRadius: '2px', minHeight: '800px' }}
-                            allowfFullScreen
-                            src="https://stackblitz.com/edit/stackblitz-starters-66bhze?embed=1&file=src%2FApp.tsx"
-                        />
+                        <div id="playground-embed" className="w-full h-full" style={{ border: '1px solid rgba(0, 0, 0, 0.1)', borderRadius: '2px', minHeight: '800px' }} />
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
Updates all instances of PrimeReact branding, package names, and documentation references to Mantle UI or @mantle-ui/react. This includes documentation, StackBlitz integration, and installation instructions to align with the new brand.

Fixes: #362 
