### PR TITLE
fix(InputNumber): allow negative input

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -106,7 +106,7 @@ export const InputNumber = React.memo(
         };
 
         const getMinusSignExpression = () => {
-            const formatter = new Intl.NumberFormat(_locale, { useGrouping: false });
+            const formatter = new Intl.NumberFormat(_locale, { useGrouping: false, minimumFractionDigits: 0, maximumFractionDigits: 0 });
 
             return new RegExp(`[${formatter.format(-1).trim().replace(_numeral.current, '')}]`, 'g');
         };
@@ -675,9 +675,11 @@ export const InputNumber = React.memo(
         };
 
         const isDecimalSign = (char) => {
-            if (_decimal.current.test(char) || isFloat(char)) {
-                _decimal.current.lastIndex = 0;
+            const isDecimal = _decimal.current.test(char);
 
+            _decimal.current.lastIndex = 0;
+
+            if (isDecimal || (!isMinusSign(char) && isFloat(char))) {
                 return true;
             }
 

--- a/components/lib/inputnumber/InputNumber.spec.js
+++ b/components/lib/inputnumber/InputNumber.spec.js
@@ -13,6 +13,18 @@ function getButtons(container) {
 }
 
 describe('InputNumber decimal precision and stepping', () => {
+    test('allows entering a minus sign into an empty input', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<InputNumber minFractionDigits={2} />);
+        const input = container.querySelector('input');
+
+        await user.click(input);
+        await user.keyboard('-');
+
+        expect(input).toHaveValue('-');
+        expect(input.selectionStart).toBe(1);
+    });
+
     test('increments correctly with step=0.25', async () => {
         const { container } = render(<InputNumber step={0.25} showButtons mode="decimal" />);
 


### PR DESCRIPTION
## Summary

- preserve a standalone minus sign while entering a negative InputNumber value
- add regression coverage for inputs with `minFractionDigits={2}`

## Root cause

The minus and decimal checks could both classify `-` as a decimal input. The minus matcher also inherited configured fraction digits, allowing decimal characters into its expression.

## Validation

- `npx jest components/lib/inputnumber/InputNumber.spec.js --runInBand --silent`
- `npx eslint components/lib/inputnumber/InputNumber.js components/lib/inputnumber/InputNumber.spec.js`

Fixes #55.