### PR TITLE
fix(docs): avoid duplicate base paths in anchor links

### DIFF
--- a/components/doc/common/docapitable.js
+++ b/components/doc/common/docapitable.js
@@ -39,7 +39,7 @@ const DocApiTable = (props) => {
                         return (
                             <React.Fragment key={i}>
                                 {i !== 0 ? '|' : ''}
-                                <Link href={router.basePath + router.pathname + `#${apiId}`} target="_self" onClick={() => onClick(apiId, 'smooth')}>
+                                <Link href={router.pathname + `#${apiId}`} target="_self" onClick={() => onClick(apiId, 'smooth')}>
                                     {sValue}
                                 </Link>
                             </React.Fragment>
@@ -52,7 +52,7 @@ const DocApiTable = (props) => {
                             {isLinkableOption ? (
                                 <span id={id + '.' + sValue} className={classNames('doc-option-name', { 'line-through cursor-pointer': !!deprecated })} title={deprecated}>
                                     {sValue}
-                                    <Link href={router.basePath + router.pathname + `#${id + '.' + sValue}`} target="_self" onClick={() => onClick(id + '.' + sValue)} className="doc-option-link">
+                                    <Link href={router.pathname + `#${id + '.' + sValue}`} target="_self" onClick={() => onClick(id + '.' + sValue)} className="doc-option-link">
                                         <i className="pi pi-link" />
                                     </Link>
                                 </span>
@@ -69,7 +69,7 @@ const DocApiTable = (props) => {
             return isLinkableOption ? (
                 <span id={id + '.' + val} className={classNames('doc-option-name', { 'line-through cursor-pointer': !!deprecated })} title={deprecated}>
                     {val}
-                    <Link href={router.basePath + router.pathname + `#${id + '.' + val}`} target="_self" onClick={() => onClick(id + '.' + val)} className="doc-option-link">
+                    <Link href={router.pathname + `#${id + '.' + val}`} target="_self" onClick={() => onClick(id + '.' + val)} className="doc-option-link">
                         <i className="pi pi-link" />
                     </Link>
                 </span>

--- a/components/doc/common/docsectionnav.js
+++ b/components/doc/common/docsectionnav.js
@@ -82,8 +82,7 @@ export function DocSectionNav({ docs = [] }) {
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const createItem = ({ id, label, children }, level = 0) => {
-        const { basePath, pathname } = router;
-        const href = `${basePath}${pathname}#${id}`;
+        const href = `${router.pathname}#${id}`;
 
         return (
             <li key={id} className={classNames('navbar-item', { 'active-navbar-item': activeId === id })}>

--- a/components/doc/common/docsectiontext.js
+++ b/components/doc/common/docsectiontext.js
@@ -20,7 +20,7 @@ export function DocSectionText(props) {
     const content = (
         <>
             {label}
-            <Link href={router.basePath + router.pathname + '#' + id} target="_self" id={id} onClick={onClick}>
+            <Link href={router.pathname + '#' + id} target="_self" id={id} onClick={onClick}>
                 #
             </Link>
         </>

--- a/components/doc/common/docsubsection.js
+++ b/components/doc/common/docsubsection.js
@@ -8,7 +8,7 @@ export function DocSubSection(props) {
         <div style={{ marginBottom: '30px' }}>
             <h3 className="doc-section-label">
                 {props.label}
-                <Link href={router.basePath + router.pathname + '#' + props.id} target="_self" id={props.id}>
+                <Link href={router.pathname + '#' + props.id} target="_self" id={props.id}>
                     #
                 </Link>
             </h3>

--- a/pages/playground/index.js
+++ b/pages/playground/index.js
@@ -28,6 +28,8 @@ export default function App() {
                 <p className="m-0">This starter is generated from the Mantle UI docs project instead of pointing to an old PrimeReact StackBlitz sample.</p>
             </Card>
         </div>
+        );
+    }
                 `
             }
         },


### PR DESCRIPTION
## Summary

Removes the manually prepended Next.js base path from internal documentation anchor links.

## Root cause

`next/link` applies the configured base path automatically. Prepending `router.basePath` produced links such as `/mantle-ui/mantle-ui/button/...` on GitHub Pages, causing the component subnavigation to return 404.

## Impact

Documentation subnavigation, section anchors, and API anchor links now resolve under `/mantle-ui/...` exactly once.

## Validation

- Targeted ESLint and Prettier checks
- `GITHUB_PAGES=true npm run build:docs:pages`
- Verified the exported site contains no `/mantle-ui/mantle-ui/` URLs

Fixes #368.