### PR TITLE
fix(AutoComplete): support IconField iconPosition

### DIFF
--- a/components/lib/autocomplete/AutoCompleteBase.js
+++ b/components/lib/autocomplete/AutoCompleteBase.js
@@ -214,7 +214,8 @@ export const AutoCompleteBase = ComponentBase.extend({
         type: 'text',
         value: null,
         virtualScrollerOptions: null,
-        children: undefined
+        children: undefined,
+        iconPosition: null
     },
     css: {
         classes,

--- a/components/lib/autocomplete/AutoCompleteBase.js
+++ b/components/lib/autocomplete/AutoCompleteBase.js
@@ -148,10 +148,10 @@ const styles = `
 export const AutoCompleteBase = ComponentBase.extend({
     defaultProps: {
         __TYPE: 'AutoComplete',
-        id: null,
         appendTo: null,
         autoFocus: false,
         autoHighlight: false,
+        children: undefined,
         className: null,
         completeMethod: null,
         delay: 300,
@@ -164,11 +164,12 @@ export const AutoCompleteBase = ComponentBase.extend({
         emptyMessage: null,
         field: null,
         forceSelection: false,
+        iconPosition: null,
+        id: null,
         inputClassName: null,
         inputId: null,
         inputRef: null,
         inputStyle: null,
-        variant: null,
         invalid: false,
         itemTemplate: null,
         loadingIcon: null,
@@ -213,9 +214,8 @@ export const AutoCompleteBase = ComponentBase.extend({
         transitionOptions: null,
         type: 'text',
         value: null,
-        virtualScrollerOptions: null,
-        children: undefined,
-        iconPosition: null
+        variant: null,
+        virtualScrollerOptions: null
     },
     css: {
         classes,

--- a/public/themes/arya-blue/theme.css
+++ b/public/themes/arya-blue/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/arya-orange/theme.css
+++ b/public/themes/arya-orange/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/arya-purple/theme.css
+++ b/public/themes/arya-purple/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/bootstrap4-dark-blue/theme.css
+++ b/public/themes/bootstrap4-dark-blue/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/bootstrap4-dark-purple/theme.css
+++ b/public/themes/bootstrap4-dark-purple/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/bootstrap4-light-blue/theme.css
+++ b/public/themes/bootstrap4-light-blue/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #495057;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #495057;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/bootstrap4-light-purple/theme.css
+++ b/public/themes/bootstrap4-light-purple/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #495057;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #495057;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/fluent-light/theme.css
+++ b/public/themes/fluent-light/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #605e5c;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #605e5c;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-amber/theme.css
+++ b/public/themes/lara-dark-amber/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-blue/theme.css
+++ b/public/themes/lara-dark-blue/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-green/theme.css
+++ b/public/themes/lara-dark-green/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-indigo/theme.css
+++ b/public/themes/lara-dark-indigo/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-pink/theme.css
+++ b/public/themes/lara-dark-pink/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-purple/theme.css
+++ b/public/themes/lara-dark-purple/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-dark-teal/theme.css
+++ b/public/themes/lara-dark-teal/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-amber/theme.css
+++ b/public/themes/lara-light-amber/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-blue/theme.css
+++ b/public/themes/lara-light-blue/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-green/theme.css
+++ b/public/themes/lara-light-green/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-indigo/theme.css
+++ b/public/themes/lara-light-indigo/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-pink/theme.css
+++ b/public/themes/lara-light-pink/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-purple/theme.css
+++ b/public/themes/lara-light-purple/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/lara-light-teal/theme.css
+++ b/public/themes/lara-light-teal/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1421,13 +1427,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #6b7280;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #888888;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/md-dark-deeppurple/theme.css
+++ b/public/themes/md-dark-deeppurple/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 3rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 3rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 3rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 3rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 3rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/md-dark-indigo/theme.css
+++ b/public/themes/md-dark-indigo/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 3rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 3rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 3rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 3rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 3rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/md-light-deeppurple/theme.css
+++ b/public/themes/md-light-deeppurple/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 3rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 3rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 3rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 3rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 3rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/md-light-indigo/theme.css
+++ b/public/themes/md-light-indigo/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 3rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 3rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 3rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 3rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 3rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/mdc-dark-deeppurple/theme.css
+++ b/public/themes/mdc-dark-deeppurple/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/mdc-dark-indigo/theme.css
+++ b/public/themes/mdc-dark-indigo/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/mdc-light-deeppurple/theme.css
+++ b/public/themes/mdc-light-deeppurple/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/mdc-light-indigo/theme.css
+++ b/public/themes/mdc-light-indigo/theme.css
@@ -1377,10 +1377,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1424,13 +1430,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/mira/theme.css
+++ b/public/themes/mira/theme.css
@@ -1379,10 +1379,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1426,13 +1432,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #81a1c1;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #81a1c1;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/nano/theme.css
+++ b/public/themes/nano/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.25rem;
     color: #697077;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.25rem;
     color: #697077;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/nova-accent/theme.css
+++ b/public/themes/nova-accent/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/nova-alt/theme.css
+++ b/public/themes/nova-alt/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
-    color: #848484;
+    color: #a6a6a6;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
-    color: #848484;
+    color: #a6a6a6;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/nova/theme.css
+++ b/public/themes/nova/theme.css
@@ -1360,10 +1360,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1407,13 +1413,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #848484;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #848484;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 1.858rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 1.858rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 1.858rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 1.858rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 1.858rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.429rem;
     color: #a6a6a6;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.429rem;
     color: #a6a6a6;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/saga-blue/theme.css
+++ b/public/themes/saga-blue/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/saga-green/theme.css
+++ b/public/themes/saga-green/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/saga-orange/theme.css
+++ b/public/themes/saga-orange/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/saga-purple/theme.css
+++ b/public/themes/saga-purple/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: #6c757d;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/soho-dark/theme.css
+++ b/public/themes/soho-dark/theme.css
@@ -1376,10 +1376,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1423,13 +1429,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/soho-light/theme.css
+++ b/public/themes/soho-light/theme.css
@@ -1376,10 +1376,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1423,13 +1429,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #708da9;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #708da9;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/tailwind-light/theme.css
+++ b/public/themes/tailwind-light/theme.css
@@ -1385,10 +1385,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1432,13 +1438,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #71717a;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #71717a;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/vela-blue/theme.css
+++ b/public/themes/vela-blue/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/vela-green/theme.css
+++ b/public/themes/vela-green/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/vela-orange/theme.css
+++ b/public/themes/vela-orange/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/vela-purple/theme.css
+++ b/public/themes/vela-purple/theme.css
@@ -1357,10 +1357,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2rem;
   }
   ::-webkit-input-placeholder {
@@ -1404,13 +1410,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/viva-dark/theme.css
+++ b/public/themes/viva-dark/theme.css
@@ -1383,10 +1383,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1430,13 +1436,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;

--- a/public/themes/viva-light/theme.css
+++ b/public/themes/viva-light/theme.css
@@ -1383,10 +1383,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right > .p-autocomplete .p-inputtext {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {
@@ -1430,13 +1436,15 @@
   .p-fluid .p-icon-field-right {
     width: 100%;
   }
-  .p-icon-field-left > .p-input-icon:first-of-type {
+  .p-icon-field-left > .p-input-icon {
     left: 0.75rem;
     color: #898989;
+    z-index: 1;
   }
-  .p-icon-field-right > .p-input-icon:last-of-type {
+  .p-icon-field-right > .p-input-icon {
     right: 0.75rem;
     color: #898989;
+    z-index: 1;
   }
   .p-inputotp {
     display: flex;


### PR DESCRIPTION
## Summary

- accept `iconPosition` in `AutoComplete` default props
- prevent `IconField`'s injected `iconPosition` prop from reaching a DOM element
- update all 56 shipped legacy themes so IconField spacing and icon placement work with AutoComplete

## Root cause

`IconField` clones its child and supplies `iconPosition`. Unlike `InputText`, `AutoComplete` did not consume this inherited prop, so React emitted an unknown DOM-property warning. The legacy themes also targeted only direct `.p-inputtext` children, which excluded AutoComplete's nested input.

## Provenance

Migrates [primefaces/primereact#7447](https://github.com/primefaces/primereact/pull/7447) in full.
Created By: @KumJungMin

Fixes #218

## Validation

- `git diff --binary <upstream-base> <upstream-head> -- components/lib/autocomplete/AutoCompleteBase.js public/themes | git apply --reverse --check`
- `npx eslint components/lib/autocomplete/AutoCompleteBase.js`
- `git diff --check`