### PR TITLE
fix: preserve Tailwind classes in passthrough

### DIFF
--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -329,12 +329,12 @@ export const Accordion = React.forwardRef((inProps, ref) => {
 
     const tabs = createTabs();
     const rootProps = mergeProps(
+        ptm('root'),
         {
             className: classNames(props.className, cx('root')),
             style: props.style
         },
-        AccordionBase.getOtherProps(props),
-        ptm('root')
+        AccordionBase.getOtherProps(props)
     );
 
     return (

--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -773,14 +773,14 @@ export const AutoComplete = React.memo(
         const input = createInput();
         const dropdown = createDropdown();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: idState,
                 ref: elementRef,
                 style: props.style,
                 className: classNames(props.className, cx('root', { focusedState }))
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         return (

--- a/components/lib/avatar/Avatar.js
+++ b/components/lib/avatar/Avatar.js
@@ -85,13 +85,13 @@ export const Avatar = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef,
             style: props.style,
             className: classNames(props.className, cx('root', { imageFailed }))
         },
-        AvatarBase.getOtherProps(props),
-        ptm('root')
+        AvatarBase.getOtherProps(props)
     );
 
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();

--- a/components/lib/avatargroup/AvatarGroup.js
+++ b/components/lib/avatargroup/AvatarGroup.js
@@ -24,13 +24,13 @@ export const AvatarGroup = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        AvatarGroupBase.getOtherProps(props),
-        ptm('root')
+        AvatarGroupBase.getOtherProps(props)
     );
 
     return <div {...rootProps}>{props.children}</div>;

--- a/components/lib/badge/Badge.js
+++ b/components/lib/badge/Badge.js
@@ -26,13 +26,13 @@ export const Badge = React.memo(
         }));
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 style: props.style,
                 className: classNames(props.className, cx('root'))
             },
-            BadgeBase.getOtherProps(props),
-            ptm('root')
+            BadgeBase.getOtherProps(props)
         );
 
         return <span {...rootProps}>{props.value}</span>;

--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -120,6 +120,7 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
     const mask = createMask();
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: props.id,
             ref: elementRef,
@@ -127,8 +128,7 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
             className: classNames(props.containerClassName, cx('root')),
             'aria-busy': props.blocked
         },
-        BlockUIBase.getOtherProps(props),
-        ptm('root')
+        BlockUIBase.getOtherProps(props)
     );
 
     return (

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -250,14 +250,14 @@ export const BreadCrumb = React.memo(
             ptm('menu')
         );
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            BreadCrumbBase.getOtherProps(props),
-            ptm('root')
+            BreadCrumbBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -113,6 +113,7 @@ export const Button = React.memo(
         const defaultAriaLabel = props.label ? props.label + (props.badge ? ' ' + props.badge : '') : props['aria-label'];
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 'aria-label': defaultAriaLabel,
@@ -120,8 +121,7 @@ export const Button = React.memo(
                 className: classNames(props.className, cx('root', { size, disabled })),
                 disabled: disabled
             },
-            ButtonBase.getOtherProps(props),
-            ptm('root')
+            ButtonBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/button/__snapshots__/Button.spec.js.snap
+++ b/components/lib/button/__snapshots__/Button.spec.js.snap
@@ -68,7 +68,7 @@ exports[`Button when badge is true it renders Button with badge 1`] = `
     <span
       class="p-badge p-component"
       data-pc-name="badge"
-      data-pc-section="root"
+      data-pc-section="badge"
     >
       test
     </span>
@@ -212,7 +212,7 @@ exports[`Button when using badge and label the aria-label should contain both va
     <span
       class="p-badge p-component"
       data-pc-name="badge"
-      data-pc-section="root"
+      data-pc-section="badge"
     >
       lost
     </span>
@@ -237,7 +237,7 @@ exports[`Button when using badge and label the aria-label should contain both va
     <span
       class="p-badge p-component"
       data-pc-name="badge"
-      data-pc-section="root"
+      data-pc-section="badge"
     >
       lost
     </span>

--- a/components/lib/buttongroup/ButtonGroup.js
+++ b/components/lib/buttongroup/ButtonGroup.js
@@ -24,13 +24,13 @@ export const ButtonGroup = React.memo(
         const isSingleButton = React.Children.count(props.children) === 1;
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(cx('root'), { 'p-button-group-single': isSingleButton }),
                 role: 'group'
             },
-            ButtonGroupBase.getOtherProps(props),
-            ptm('root')
+            ButtonGroupBase.getOtherProps(props)
         );
 
         return <span {...rootProps}>{props.children}</span>;

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -4461,13 +4461,13 @@ export const Calendar = React.memo(
         const yearPicker = createYearPicker();
         const isFilled = DomHandler.hasClass(inputRef.current, 'p-filled') && inputRef.current.value !== '';
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 className: classNames(props.className, cx('root', { focusedState, isFilled, panelVisible: visible })),
                 style: props.style
             },
-            CalendarBase.getOtherProps(props),
-            ptm('root')
+            CalendarBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/card/Card.js
+++ b/components/lib/card/Card.js
@@ -92,14 +92,14 @@ export const Card = React.forwardRef((inProps, ref) => {
     }, [elementRef, ref]);
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: props.id,
             ref: elementRef,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        CardBase.getOtherProps(props),
-        ptm('root')
+        CardBase.getOtherProps(props)
     );
 
     const header = createHeader();

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -805,6 +805,7 @@ export const Carousel = React.memo(
         const header = createHeader();
         const footer = createFooter();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
@@ -812,8 +813,7 @@ export const Carousel = React.memo(
                 style: props.style,
                 role: 'region'
             },
-            CarouselBase.getOtherProps(props),
-            ptm('root')
+            CarouselBase.getOtherProps(props)
         );
 
         const contentProps = mergeProps(

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -528,6 +528,7 @@ export const CascadeSelect = React.memo(
             const dropdownIcon = props.loading ? createLoadingIcon() : createDropdownIcon();
             const overlay = createOverlay();
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     id: props.id,
                     ref: elementRef,
@@ -535,8 +536,7 @@ export const CascadeSelect = React.memo(
                     style: props.style,
                     onClick: (e) => onClick(e)
                 },
-                otherProps,
-                ptm('root')
+                otherProps
             );
 
             return (

--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -93,14 +93,14 @@ const MantleUIChart = React.memo(
         const title = props.options && props.options.plugins && props.options.plugins.title && props.options.plugins.title.text;
         const ariaLabel = props.ariaLabel || title;
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 style: sx('root'),
                 className: classNames(props.className, cx('root'))
             },
-            ChartBase.getOtherProps(props),
-            ptm('root')
+            ChartBase.getOtherProps(props)
         );
         const canvasProps = mergeProps(
             {

--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -106,6 +106,7 @@ export const Checkbox = React.memo(
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
         const otherProps = CheckboxBase.getOtherProps(props);
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 className: classNames(props.className, cx('root', { checked, context })),
@@ -115,8 +116,7 @@ export const Checkbox = React.memo(
                 onContextMenu: props.onContextMenu,
                 onMouseDown: props.onMouseDown
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         const createInputElement = () => {

--- a/components/lib/chip/Chip.js
+++ b/components/lib/chip/Chip.js
@@ -105,14 +105,14 @@ export const Chip = React.memo(
             const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();
 
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     ref: elementRef,
                     style: props.style,
                     className: classNames(props.className, cx('root')),
                     'aria-label': props.label
                 },
-                ChipBase.getOtherProps(props),
-                ptm('root')
+                ChipBase.getOtherProps(props)
             );
 
             return (

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -449,13 +449,13 @@ export const Chips = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const list = createList();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 className: classNames(props.className, cx('root', { isFilled, focusedState, disabled: props.disabled, invalid: props.invalid })),
                 style: props.style
-            },
-            ptm('root')
+            }
         );
 
         return (

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -448,15 +448,12 @@ export const Chips = React.memo(
         const otherProps = ChipsBase.getOtherProps(props);
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const list = createList();
-        const rootProps = mergeProps(
-            ptm('root'),
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root', { isFilled, focusedState, disabled: props.disabled, invalid: props.invalid })),
-                style: props.style
-            }
-        );
+        const rootProps = mergeProps(ptm('root'), {
+            id: props.id,
+            ref: elementRef,
+            className: classNames(props.className, cx('root', { isFilled, focusedState, disabled: props.disabled, invalid: props.invalid })),
+            style: props.style
+        });
 
         return (
             <>

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -641,14 +641,14 @@ export const ColorPicker = React.memo(
         const content = createContent();
         const input = createInput();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 style: props.style,
                 className: classNames(props.className, cx('root'))
             },
-            ColorPickerBase.getOtherProps(props),
-            ptm('root')
+            ColorPickerBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -358,6 +358,7 @@ export const ConfirmPopup = React.memo(
         };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: overlayRef,
                 id: getPropValue('id'),
@@ -365,8 +366,7 @@ export const ConfirmPopup = React.memo(
                 style: getPropValue('style'),
                 onClick: onPanelClick
             },
-            ConfirmPopupBase.getOtherProps(props),
-            ptm('root')
+            ConfirmPopupBase.getOtherProps(props)
         );
 
         const transitionProps = mergeProps(

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -686,6 +686,7 @@ export const ContextMenu = React.memo(
 
         const createContextMenu = () => {
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     id: props.id,
                     className: classNames(props.className, cx('root', { context })),
@@ -694,7 +695,6 @@ export const ContextMenu = React.memo(
                     onMouseEnter: (e) => onMenuMouseEnter(e)
                 },
                 ContextMenuBase.getOtherProps(props),
-                ptm('root')
             );
 
             const transitionProps = mergeProps(

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -694,7 +694,7 @@ export const ContextMenu = React.memo(
                     onClick: (e) => onMenuClick(e),
                     onMouseEnter: (e) => onMenuMouseEnter(e)
                 },
-                ContextMenuBase.getOtherProps(props),
+                ContextMenuBase.getOtherProps(props)
             );
 
             const transitionProps = mergeProps(

--- a/components/lib/datascroller/DataScroller.js
+++ b/components/lib/datascroller/DataScroller.js
@@ -239,13 +239,13 @@ export const DataScroller = React.memo(
         const content = createContent();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 className: classNames(props.className, cx('root'))
             },
-            DataScrollerBase.getOtherProps(props),
-            ptm('root')
+            DataScrollerBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -2094,6 +2094,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const resizeHelper = createResizeHelper();
     const reorderIndicators = createReorderIndicators();
     const rootProps = mergeProps(
+        ptCallbacks.ptm('root'),
         {
             id: props.id,
             className: classNames(props.className, ptCallbacks.cx('root', { selectable })),
@@ -2101,8 +2102,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             'data-scrollselectors': '.p-datatable-wrapper',
             'data-showgridlines': props.showGridlines
         },
-        DataTableBase.getOtherProps(props),
-        ptCallbacks.ptm('root')
+        DataTableBase.getOtherProps(props)
     );
 
     return (

--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -31,13 +31,13 @@ export const DataViewLayoutOptions = React.memo((inProps) => {
     const listIcon = IconUtils.getJSXIcon(props.listIcon || <BarsIcon {...listIconProps} />, { ...listIconProps }, { props });
     const gridIcon = IconUtils.getJSXIcon(props.gridIcon || <ThLargeIcon {...gridIconProps} />, { ...gridIconProps }, { props });
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: props.id,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        DataViewLayoutOptionsBase.getOtherProps(props),
-        ptm('root')
+        DataViewLayoutOptionsBase.getOtherProps(props)
     );
 
     const listButtonProps = mergeProps(
@@ -325,14 +325,14 @@ export const DataView = React.memo(
         const footer = createFooter();
         const content = createContent(data);
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 style: props.style,
                 className: classNames(props.className, cx('root'))
             },
-            DataViewBase.getOtherProps(props),
-            ptm('root')
+            DataViewBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/deferredcontent/DeferredContent.js
+++ b/components/lib/deferredcontent/DeferredContent.js
@@ -57,11 +57,11 @@ export const DeferredContent = React.forwardRef((inProps, ref) => {
     });
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef
         },
-        DeferredContentBase.getOtherProps(props),
-        ptm('root')
+        DeferredContentBase.getOtherProps(props)
     );
 
     return <div {...rootProps}>{loadedState && props.children}</div>;

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -659,6 +659,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         );
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: dialogRef,
                 id: idState,
@@ -671,8 +672,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
                 'aria-modal': props.modal,
                 onPointerDown: onDialogPointerDown
             },
-            DialogBase.getOtherProps(props),
-            ptm('root')
+            DialogBase.getOtherProps(props)
         );
 
         const transitionProps = mergeProps(

--- a/components/lib/divider/Divider.js
+++ b/components/lib/divider/Divider.js
@@ -25,6 +25,7 @@ export const Divider = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef,
             style: sx('root'),
@@ -32,8 +33,7 @@ export const Divider = React.forwardRef((inProps, ref) => {
             'aria-orientation': props.layout,
             role: 'separator'
         },
-        DividerBase.getOtherProps(props),
-        ptm('root')
+        DividerBase.getOtherProps(props)
     );
 
     const contentProps = mergeProps(

--- a/components/lib/dock/Dock.js
+++ b/components/lib/dock/Dock.js
@@ -326,12 +326,12 @@ export const Dock = React.memo(
         const list = createList();
         const footer = createFooter();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            DockBase.getOtherProps(props),
-            ptm('root')
+            DockBase.getOtherProps(props)
         );
 
         const containerProps = mergeProps(

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1203,6 +1203,7 @@ export const Dropdown = React.memo(
         const dropdownIcon = props.loading ? createLoadingIcon() : createDropdownIcon();
         const clearIcon = createClearIcon();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
@@ -1216,8 +1217,7 @@ export const Dropdown = React.memo(
                 'data-p-focus': focusedState,
                 'aria-activedescendant': focusedState ? `dropdownItem_${focusedOptionIndex}` : undefined
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         const firstHiddenFocusableElementProps = mergeProps(

--- a/components/lib/editor/Editor.js
+++ b/components/lib/editor/Editor.js
@@ -257,11 +257,11 @@ export const Editor = React.memo(
         );
         const content = <div {...contentProps} />;
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root'))
             },
-            EditorBase.getOtherProps(props),
-            ptm('root')
+            EditorBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/fieldset/Fieldset.js
+++ b/components/lib/fieldset/Fieldset.js
@@ -195,6 +195,7 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: idState,
             ref: elementRef,
@@ -202,8 +203,7 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
             className: classNames(props.className, cx('root')),
             onClick: props.onClick
         },
-        FieldsetBase.getOtherProps(props),
-        ptm('root')
+        FieldsetBase.getOtherProps(props)
     );
 
     const legend = createLegend();

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -647,13 +647,13 @@ export const FileUpload = React.memo(
             }
 
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     id: props.id,
                     className: classNames(props.className, cx('root')),
                     style: props.style
                 },
-                FileUploadBase.getOtherProps(props),
-                ptm('root')
+                FileUploadBase.getOtherProps(props)
             );
 
             const contentProps = mergeProps(
@@ -715,12 +715,12 @@ export const FileUpload = React.memo(
             );
             const input = !hasFiles && <input {...inputProps} />;
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     className: classNames(props.className, cx('root')),
                     style: props.style
                 },
-                FileUploadBase.getOtherProps(props),
-                ptm('root')
+                FileUploadBase.getOtherProps(props)
             );
 
             const basicButtonProps = mergeProps(

--- a/components/lib/floatlabel/FloatLabel.js
+++ b/components/lib/floatlabel/FloatLabel.js
@@ -22,12 +22,12 @@ export const FloatLabel = React.memo(
         }, [elementRef, ref]);
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(cx('root'))
             },
-            FloatLabelBase.getOtherProps(props),
-            ptm('root')
+            FloatLabelBase.getOtherProps(props)
         );
 
         return <span {...rootProps}>{props.children}</span>;

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -216,6 +216,7 @@ export const Galleria = React.memo(
             const footer = createFooter();
 
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     ref: elementRef,
                     id: id,
@@ -223,8 +224,7 @@ export const Galleria = React.memo(
                     style: props.style,
                     role: 'region'
                 },
-                GalleriaBase.getOtherProps(props),
-                ptm('root')
+                GalleriaBase.getOtherProps(props)
             );
 
             const contentProps = mergeProps(

--- a/components/lib/iconfield/IconField.js
+++ b/components/lib/iconfield/IconField.js
@@ -20,11 +20,11 @@ export const IconField = React.memo(
         });
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { iconPosition: props.iconPosition }))
             },
-            IconFieldBase.getOtherProps(props),
-            ptm('root')
+            IconFieldBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -382,12 +382,12 @@ export const Image = React.memo(
         const image = props.src && <img {...imageProp} alt={alt} />;
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root'))
             },
-            ImageBase.getOtherProps(props),
-            ptm('root')
+            ImageBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/inplace/Inplace.js
+++ b/components/lib/inplace/Inplace.js
@@ -151,13 +151,13 @@ export const Inplace = React.forwardRef((inProps, ref) => {
     const children = createChildren();
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef,
             className: classNames(props.className, cx('root')),
             'aria-live': 'polite'
         },
-        InplaceBase.getOtherProps(props),
-        ptm('root')
+        InplaceBase.getOtherProps(props)
     );
 
     return <div {...rootProps}>{children}</div>;

--- a/components/lib/inputicon/InputIcon.js
+++ b/components/lib/inputicon/InputIcon.js
@@ -20,11 +20,11 @@ export const InputIcon = React.memo(
         });
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root'))
             },
-            InputIconBase.getOtherProps(props),
-            ptm('root')
+            InputIconBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -1395,13 +1395,13 @@ export const InputNumber = React.memo(
         const inputElement = createInputElement();
         const buttonGroup = createButtonGroup();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 className: classNames(props.className, cx('root', { focusedState, stacked, horizontal, vertical })),
                 style: props.style
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         return (

--- a/components/lib/inputswitch/InputSwitch.js
+++ b/components/lib/inputswitch/InputSwitch.js
@@ -72,6 +72,7 @@ export const InputSwitch = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { checked })),
                 style: props.style,
@@ -80,8 +81,7 @@ export const InputSwitch = React.memo(
                 'data-p-highlight': checked,
                 'data-p-disabled': props.disabled
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         const inputProps = mergeProps(

--- a/components/lib/inputtext/InputText.js
+++ b/components/lib/inputtext/InputText.js
@@ -79,6 +79,7 @@ export const InputText = React.memo(
         }, [props.disabled, isFilled]);
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { context, isFilled })),
                 autoComplete: props.autoComplete,
@@ -87,8 +88,7 @@ export const InputText = React.memo(
                 onKeyDown: onKeyDown,
                 onPaste: onPaste
             },
-            InputTextBase.getOtherProps(props),
-            ptm('root')
+            InputTextBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -136,6 +136,7 @@ export const InputTextarea = React.memo(
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root', { context, isFilled })),
@@ -148,8 +149,7 @@ export const InputTextarea = React.memo(
                 onInput: onInput,
                 onPaste: onPaste
             },
-            InputTextareaBase.getOtherProps(props),
-            ptm('root')
+            InputTextareaBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -241,13 +241,13 @@ export const Knob = React.memo(
         const text = props.showValue && <text {...labelProps}>{valueToDisplay()}</text>;
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: classNames(props.className, cx('root')),
                 style: props.style
-            },
-            ptm('root')
+            }
         );
 
         const svgProps = mergeProps(

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -240,15 +240,12 @@ export const Knob = React.memo(
 
         const text = props.showValue && <text {...labelProps}>{valueToDisplay()}</text>;
 
-        const rootProps = mergeProps(
-            ptm('root'),
-            {
-                ref: elementRef,
-                id: props.id,
-                className: classNames(props.className, cx('root')),
-                style: props.style
-            }
-        );
+        const rootProps = mergeProps(ptm('root'), {
+            ref: elementRef,
+            id: props.id,
+            className: classNames(props.className, cx('root')),
+            style: props.style
+        });
 
         const svgProps = mergeProps(
             {

--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -876,14 +876,14 @@ export const ListBox = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptCallbacks.ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: ptCallbacks.cx('root'),
                 style: props.style
             },
-            ListBoxBase.getOtherProps(props),
-            ptCallbacks.ptm('root')
+            ListBoxBase.getOtherProps(props)
         );
 
         const hiddenFirstElement = mergeProps(

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -1277,13 +1277,13 @@ export const MegaMenu = React.memo(
         };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { mobileActiveState })),
                 id: idState,
                 style: props.style
             },
-            MegaMenuBase.getOtherProps(props),
-            ptm('root')
+            MegaMenuBase.getOtherProps(props)
         );
 
         const menu = createMenu();

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -558,14 +558,14 @@ export const Mention = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: classNames(props.className, cx('root', { focusedState, isFilled })),
                 style: props.style
             },
-            MentionBase.getOtherProps(props),
-            ptm('root')
+            MentionBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -455,13 +455,13 @@ export const Menu = React.memo(
             if (props.model) {
                 const menuitems = createMenu();
                 const rootProps = mergeProps(
+                    ptm('root'),
                     {
                         className: classNames(props.className, cx('root', { context })),
                         style: props.style,
                         onClick: (e) => onPanelClick(e)
                     },
-                    MenuBase.getOtherProps(props),
-                    ptm('root')
+                    MenuBase.getOtherProps(props)
                 );
 
                 const menuProps = mergeProps(

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -675,14 +675,14 @@ export const Menubar = React.memo(
             />
         );
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 className: classNames(props.className, cx('root', { mobileActiveState })),
                 style: props.style
             },
-            MenubarBase.getOtherProps(props),
-            ptm('root')
+            MenubarBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/message/Message.js
+++ b/components/lib/message/Message.js
@@ -83,6 +83,7 @@ export const Message = React.memo(
         const content = createContent();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root')),
                 style: props.style,
@@ -90,8 +91,7 @@ export const Message = React.memo(
                 'aria-live': 'polite',
                 'aria-atomic': 'true'
             },
-            MessageBase.getOtherProps(props),
-            ptm('root')
+            MessageBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -94,13 +94,13 @@ export const Messages = React.memo(
         }));
 
         const rootProps = mergeProps(
+            ptCallbacks.ptm('root'),
             {
                 id: props.id,
                 className: props.className,
                 style: props.style
             },
-            MessagesBase.getOtherProps(props),
-            ptCallbacks.ptm('root')
+            MessagesBase.getOtherProps(props)
         );
 
         const transitionProps = mergeProps(

--- a/components/lib/messages/UIMessage.js
+++ b/components/lib/messages/UIMessage.js
@@ -162,6 +162,7 @@ export const UIMessage = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptmo(pt, 'root', { ...params, hostName: props.hostName }),
             {
                 ref,
                 className: classNames(_className, cx('uimessage.root', { severity })),
@@ -171,8 +172,7 @@ export const UIMessage = React.memo(
                 'aria-atomic': 'true',
                 onClick
             },
-            getPTOptions('root', parentParams),
-            ptmo(pt, 'root', { ...params, hostName: props.hostName })
+            getPTOptions('root', parentParams)
         );
 
         return (

--- a/components/lib/metergroup/MeterGroup.js
+++ b/components/lib/metergroup/MeterGroup.js
@@ -36,11 +36,11 @@ export const MeterGroup = (inProps) => {
     };
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             className: classNames(props.className, cx('root', { orientation }))
         },
-        MeterGroupBase.getOtherProps(props),
-        ptm('root')
+        MeterGroupBase.getOtherProps(props)
     );
 
     const createMeters = () => {

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -1155,6 +1155,7 @@ export const MultiSelect = React.memo(
         const clearIcon = !props.inline && createClearIcon();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
@@ -1163,8 +1164,7 @@ export const MultiSelect = React.memo(
                 ...otherProps,
                 onClick: onClick
             },
-            MultiSelectBase.getOtherProps(props),
-            ptm('root')
+            MultiSelectBase.getOtherProps(props)
         );
 
         const hiddenInputWrapperProps = mergeProps(

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -156,6 +156,7 @@ export const MultiStateCheckbox = React.memo(
         const ariaValueLabel = selectedOption ? getOptionAriaLabel(selectedOption) : ariaLabel('nullLabel');
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
@@ -163,8 +164,7 @@ export const MultiStateCheckbox = React.memo(
                 style: props.style,
                 onClick: onClick
             },
-            MultiStateCheckboxBase.getOtherProps(props),
-            ptm('root')
+            MultiStateCheckboxBase.getOtherProps(props)
         );
 
         const inputId = React.useMemo(() => props.id || UniqueComponentId(), [props.id]);

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -469,14 +469,14 @@ export const OrderList = React.memo(
         });
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            OrderListBase.getOtherProps(props),
-            ptm('root')
+            OrderListBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/organizationchart/OrganizationChart.js
+++ b/components/lib/organizationchart/OrganizationChart.js
@@ -80,14 +80,14 @@ export const OrganizationChart = React.memo(
         }));
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 style: props.style,
                 className: classNames(props.className, cx('root'))
             },
-            OrganizationChartBase.getOtherProps(props),
-            ptm('root')
+            OrganizationChartBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -280,14 +280,14 @@ export const OverlayPanel = React.forwardRef((inProps, ref) => {
     const createElement = () => {
         const closeIcon = createCloseIcon();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 className: classNames(props.className, cx('root', { context })),
                 style: props.style,
                 onClick: (e) => onPanelClick(e)
             },
-            OverlayPanelBase.getOtherProps(props),
-            ptm('root')
+            OverlayPanelBase.getOtherProps(props)
         );
 
         const contentProps = mergeProps(

--- a/components/lib/paginator/Paginator.js
+++ b/components/lib/paginator/Paginator.js
@@ -305,13 +305,13 @@ export const Paginator = React.memo(
         );
         const rightElement = rightContent && <div {...endProps}>{rightContent}</div>;
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            PaginatorBase.getOtherProps(props),
-            ptm('root')
+            PaginatorBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/panel/Panel.js
+++ b/components/lib/panel/Panel.js
@@ -244,14 +244,14 @@ export const Panel = React.forwardRef((inProps, ref) => {
     };
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: idState,
             ref: elementRef,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        PanelBase.getOtherProps(props),
-        ptm('root')
+        PanelBase.getOtherProps(props)
     );
     const header = createHeader();
     const content = createContent();

--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -431,14 +431,14 @@ export const PanelMenu = React.memo(
 
         const panels = createPanels();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 id: props.id,
                 style: props.style
             },
-            PanelMenuBase.getOtherProps(props),
-            ptm('root')
+            PanelMenuBase.getOtherProps(props)
         );
 
         return <div {...rootProps}>{panels}</div>;

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -448,13 +448,13 @@ export const Password = React.memo(
         const panel = createPanel();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: classNames(props.className, cx('root', { isFilled, focusedState })),
                 style: props.style
-            },
-            ptm('root')
+            }
         );
 
         const inputTextProps = mergeProps(

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -447,15 +447,12 @@ export const Password = React.memo(
         const icon = createIcon();
         const panel = createPanel();
 
-        const rootProps = mergeProps(
-            ptm('root'),
-            {
-                ref: elementRef,
-                id: props.id,
-                className: classNames(props.className, cx('root', { isFilled, focusedState })),
-                style: props.style
-            }
-        );
+        const rootProps = mergeProps(ptm('root'), {
+            ref: elementRef,
+            id: props.id,
+            className: classNames(props.className, cx('root', { isFilled, focusedState })),
+            style: props.style
+        });
 
         const inputTextProps = mergeProps(
             {

--- a/components/lib/picklist/PickList.js
+++ b/components/lib/picklist/PickList.js
@@ -612,14 +612,14 @@ export const PickList = React.memo(
         const targetItemTemplate = props.targetItemTemplate ? props.targetItemTemplate : props.itemTemplate;
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: attributeSelectorState,
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            PickListBase.getOtherProps(props),
-            ptm('root')
+            PickListBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/progressbar/ProgressBar.js
+++ b/components/lib/progressbar/ProgressBar.js
@@ -31,6 +31,7 @@ export const ProgressBar = React.memo(
         const createDeterminate = () => {
             const label = createLabel();
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     className: classNames(props.className, cx('root')),
                     style: props.style,
@@ -39,8 +40,7 @@ export const ProgressBar = React.memo(
                     'aria-valuenow': props.value,
                     'aria-valuemax': '100'
                 },
-                ProgressBarBase.getOtherProps(props),
-                ptm('root')
+                ProgressBarBase.getOtherProps(props)
             );
             const valueProps = mergeProps(
                 {
@@ -66,6 +66,7 @@ export const ProgressBar = React.memo(
 
         const createIndeterminate = () => {
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     className: classNames(props.className, cx('root')),
                     style: props.style,
@@ -74,8 +75,7 @@ export const ProgressBar = React.memo(
                     'aria-valuenow': props.value,
                     'aria-valuemax': '100'
                 },
-                ProgressBarBase.getOtherProps(props),
-                ptm('root')
+                ProgressBarBase.getOtherProps(props)
             );
 
             const containerProps = mergeProps(

--- a/components/lib/progressspinner/ProgressSpinner.js
+++ b/components/lib/progressspinner/ProgressSpinner.js
@@ -25,6 +25,7 @@ export const ProgressSpinner = React.memo(
         }));
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
@@ -33,8 +34,7 @@ export const ProgressSpinner = React.memo(
                 role: 'progressbar',
                 'aria-busy': true
             },
-            ProgressSpinnerBase.getOtherProps(props),
-            ptm('root')
+            ProgressSpinnerBase.getOtherProps(props)
         );
 
         const spinnerProps = mergeProps(

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -110,14 +110,14 @@ export const RadioButton = React.memo(
         const otherProps = RadioButtonBase.getOtherProps(props);
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 className: classNames(props.className, cx('root', { context })),
                 style: props.style,
                 'data-p-checked': props.checked
             },
-            otherProps,
-            ptm('root')
+            otherProps
         );
 
         delete rootProps.input;

--- a/components/lib/rating/Rating.js
+++ b/components/lib/rating/Rating.js
@@ -194,14 +194,14 @@ export const Rating = React.memo(
 
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            RatingBase.getOtherProps(props),
-            ptm('root')
+            RatingBase.getOtherProps(props)
         );
 
         const cancelIcon = createCancelIcon();

--- a/components/lib/ripple/Ripple.js
+++ b/components/lib/ripple/Ripple.js
@@ -114,12 +114,12 @@ export const Ripple = React.memo(
         }
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 'aria-hidden': true,
                 className: classNames(cx('root'))
             },
-            RippleBase.getOtherProps(props),
-            ptm('root')
+            RippleBase.getOtherProps(props)
         );
 
         return <span role="presentation" ref={inkRef} {...rootProps} onAnimationEnd={onAnimationEnd} />;

--- a/components/lib/row/Row.js
+++ b/components/lib/row/Row.js
@@ -13,12 +13,12 @@ export const Row = (inProps) => {
     });
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             className: props.className,
             style: props.style
         },
-        RowBase.getOtherProps(props),
-        ptm('root')
+        RowBase.getOtherProps(props)
     );
 
     return <tr {...rootProps}>{props.children}</tr>;

--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -292,14 +292,14 @@ export const ScrollPanel = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: props.id,
             ref: containerRef,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        ScrollPanelBase.getOtherProps(props),
-        ptm('root')
+        ScrollPanelBase.getOtherProps(props)
     );
 
     const wrapperProps = mergeProps(

--- a/components/lib/scrolltop/ScrollTop.js
+++ b/components/lib/scrolltop/ScrollTop.js
@@ -97,6 +97,7 @@ export const ScrollTop = React.memo(
         const scrollIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
         const scrollTopAriaLabel = localeOption('aria') ? localeOption('aria').scrollTop : undefined;
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: scrollElementRef,
                 type: 'button',
@@ -105,8 +106,7 @@ export const ScrollTop = React.memo(
                 onClick,
                 'aria-label': scrollTopAriaLabel
             },
-            ScrollTopBase.getOtherProps(props),
-            ptm('root')
+            ScrollTopBase.getOtherProps(props)
         );
 
         const transitionProps = mergeProps(

--- a/components/lib/selectbutton/SelectButton.js
+++ b/components/lib/selectbutton/SelectButton.js
@@ -137,6 +137,7 @@ export const SelectButton = React.memo(
         const items = createItems();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
@@ -144,8 +145,7 @@ export const SelectButton = React.memo(
                 style: props.style,
                 role: 'group'
             },
-            SelectButtonBase.getOtherProps(props),
-            ptm('root')
+            SelectButtonBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/sidebar/Sidebar.js
+++ b/components/lib/sidebar/Sidebar.js
@@ -212,14 +212,14 @@ export const Sidebar = React.forwardRef((inProps, ref) => {
     );
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: props.id,
             className: classNames(props.className, cx('root', { context })),
             style: props.style,
             role: 'complementary'
         },
-        SidebarBase.getOtherProps(props),
-        ptm('root')
+        SidebarBase.getOtherProps(props)
     );
 
     const headerProps = mergeProps(

--- a/components/lib/skeleton/Skeleton.js
+++ b/components/lib/skeleton/Skeleton.js
@@ -26,14 +26,14 @@ export const Skeleton = React.memo(
         const style = props.size ? { width: props.size, height: props.size, borderRadius: props.borderRadius } : { width: props.width, height: props.height, borderRadius: props.borderRadius };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: { ...style, ...sx('root') },
                 'aria-hidden': true
             },
-            SkeletonBase.getOtherProps(props),
-            ptm('root')
+            SkeletonBase.getOtherProps(props)
         );
 
         return <div {...rootProps} />;

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -178,6 +178,7 @@ export const SlideMenu = React.memo(
             const wrapperStyle = { height: props.viewportHeight + 'px' };
             const backward = createBackward();
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     ref: menuRef,
                     id: props.id,
@@ -185,8 +186,7 @@ export const SlideMenu = React.memo(
                     style: props.style,
                     onClick: (e) => onPanelClick(e)
                 },
-                SlideMenuBase.getOtherProps(props),
-                ptm('root')
+                SlideMenuBase.getOtherProps(props)
             );
 
             const wrapperProps = mergeProps(

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -356,13 +356,13 @@ export const Slider = React.memo(
 
         const content = props.range ? createRangeSlider() : createSingleSlider();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 style: props.style,
                 className: classNames(props.className, cx('root', { vertical, horizontal })),
                 onClick: onBarClick
             },
-            SliderBase.getOtherProps(props),
-            ptm('root')
+            SliderBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/speeddial/SpeedDial.js
+++ b/components/lib/speeddial/SpeedDial.js
@@ -592,13 +592,13 @@ export const SpeedDial = React.memo(
         const list = createList();
         const mask = createMask();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { visible })),
                 style: { ...props.style, ...sx('root') },
                 id: idState
             },
-            SpeedDialBase.getOtherProps(props),
-            ptm('root')
+            SpeedDialBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -131,14 +131,14 @@ export const SplitButton = React.memo(
         };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: idState,
                 className: classNames(props.className, cx('root', { size })),
                 style: props.style
             },
-            SplitButtonBase.getOtherProps(props),
-            ptm('root')
+            SplitButtonBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -468,14 +468,14 @@ export const Splitter = React.memo(
         };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 style: props.style,
                 className: classNames(props.className, cx('root')),
                 'data-p-splitter-resizing': false
             },
-            SplitterBase.getOtherProps(props),
-            ptm('root')
+            SplitterBase.getOtherProps(props)
         );
 
         const panels = createPanels();

--- a/components/lib/stepper/Stepper.js
+++ b/components/lib/stepper/Stepper.js
@@ -332,12 +332,12 @@ export const Stepper = React.memo(
         };
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(cx('root')),
                 role: 'tablist'
             },
-            StepperBase.getOtherProps(props),
-            ptm('root')
+            StepperBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/steps/Steps.js
+++ b/components/lib/steps/Steps.js
@@ -307,14 +307,14 @@ export const Steps = React.memo(
         }));
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: props.style
             },
-            StepsBase.getOtherProps(props),
-            ptm('root')
+            StepsBase.getOtherProps(props)
         );
 
         const items = createItems();

--- a/components/lib/tabmenu/TabMenu.js
+++ b/components/lib/tabmenu/TabMenu.js
@@ -329,14 +329,14 @@ export const TabMenu = React.memo(
             );
 
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     id: props.id,
                     ref: elementRef,
                     className: classNames(props.className, cx('root')),
                     style: props.style
                 },
-                TabMenuBase.getOtherProps(props),
-                ptm('root')
+                TabMenuBase.getOtherProps(props)
             );
 
             return (

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -581,14 +581,14 @@ export const TabView = React.forwardRef((inProps, ref) => {
     };
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             id: idState,
             ref: elementRef,
             style: props.style,
             className: classNames(props.className, cx('root'))
         },
-        TabViewBase.getOtherProps(props),
-        ptm('root')
+        TabViewBase.getOtherProps(props)
     );
 
     const navContainerProps = mergeProps(

--- a/components/lib/tag/Tag.js
+++ b/components/lib/tag/Tag.js
@@ -32,13 +32,13 @@ export const Tag = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
+        ptm('root'),
         {
             ref: elementRef,
             className: classNames(props.className, cx('root')),
             style: props.style
         },
-        TagBase.getOtherProps(props),
-        ptm('root')
+        TagBase.getOtherProps(props)
     );
 
     const valueProps = mergeProps(

--- a/components/lib/terminal/Terminal.js
+++ b/components/lib/terminal/Terminal.js
@@ -200,6 +200,7 @@ export const Terminal = React.memo(
         const content = createContent();
         const prompt = createPromptContainer();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
@@ -207,8 +208,7 @@ export const Terminal = React.memo(
                 style: props.style,
                 onClick
             },
-            TerminalBase.getOtherProps(props),
-            ptm('root')
+            TerminalBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -681,6 +681,7 @@ export const TieredMenu = React.memo(
 
         const createElement = () => {
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     ref: containerRef,
                     id: props.id,
@@ -688,8 +689,7 @@ export const TieredMenu = React.memo(
                     style: props.style,
                     onClick: onPanelClick
                 },
-                TieredMenuBase.getOtherProps(props),
-                ptm('root')
+                TieredMenuBase.getOtherProps(props)
             );
 
             const transitionProps = mergeProps(

--- a/components/lib/timeline/Timeline.js
+++ b/components/lib/timeline/Timeline.js
@@ -98,12 +98,12 @@ export const Timeline = React.memo(
         const events = createEvents();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root'))
             },
-            TimelineBase.getOtherProps(props),
-            ptm('root')
+            TimelineBase.getOtherProps(props)
         );
 
         return <div {...rootProps}>{events}</div>;

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -116,14 +116,14 @@ export const Toast = React.memo(
 
         const createElement = () => {
             const rootProps = mergeProps(
+                ptCallbacks.ptm('root'),
                 {
                     ref: containerRef,
                     id: props.id,
                     className: ptCallbacks.cx('root', { context }),
                     style: ptCallbacks.sx('root')
                 },
-                ToastBase.getOtherProps(props),
-                ptCallbacks.ptm('root')
+                ToastBase.getOtherProps(props)
             );
 
             const transitionProps = mergeProps(

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -98,6 +98,7 @@ export const ToggleButton = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 id: props.id,
@@ -105,8 +106,7 @@ export const ToggleButton = React.memo(
                 'data-p-highlight': props.checked,
                 'data-p-disabled': props.disabled
             },
-            ToggleButtonBase.getOtherProps(props),
-            ptm('root')
+            ToggleButtonBase.getOtherProps(props)
         );
 
         const inputProps = mergeProps(

--- a/components/lib/toolbar/Toolbar.js
+++ b/components/lib/toolbar/Toolbar.js
@@ -47,6 +47,7 @@ export const Toolbar = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 id: props.id,
                 ref: elementRef,
@@ -54,8 +55,7 @@ export const Toolbar = React.memo(
                 className: classNames(props.className, cx('root')),
                 role: 'toolbar'
             },
-            ToolbarBase.getOtherProps(props),
-            ptm('root')
+            ToolbarBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -520,6 +520,7 @@ export const Tooltip = React.memo(
         const createElement = () => {
             const empty = isTargetContentEmpty(currentTargetRef.current);
             const rootProps = mergeProps(
+                ptm('root'),
                 {
                     id: props.id,
                     className: classNames(props.className, cx('root', { positionState, classNameState })),
@@ -529,8 +530,7 @@ export const Tooltip = React.memo(
                     onMouseEnter: (e) => onMouseEnter(e),
                     onMouseLeave: (e) => onMouseLeave(e)
                 },
-                TooltipBase.getOtherProps(props),
-                ptm('root')
+                TooltipBase.getOtherProps(props)
             );
 
             const arrowProps = mergeProps(

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -660,14 +660,14 @@ export const Tree = React.memo(
         const footer = createFooter();
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root')),
                 style: props.style,
                 id: props.id
             },
-            TreeBase.getOtherProps(props),
-            ptm('root')
+            TreeBase.getOtherProps(props)
         );
 
         return (

--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -851,6 +851,7 @@ export const TreeSelect = React.memo(
             ptm('lastHiddenFocusableElementOnOverlay')
         );
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className: classNames(
@@ -865,8 +866,7 @@ export const TreeSelect = React.memo(
                 style: props.style,
                 onClick: onClick
             },
-            TreeSelectBase.getOtherProps(props),
-            ptm('root')
+            TreeSelectBase.getOtherProps(props)
         );
 
         const keyboardHelper = createKeyboardHelper();

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -1417,6 +1417,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     );
 
     const rootProps = mergeProps(
+        ptCallbacks.ptm('root'),
         {
             role: 'table',
             id: props.id,
@@ -1424,8 +1425,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
             style: props.style,
             'data-scrollselectors': '.p-treetable-wrapper'
         },
-        TreeTableBase.getOtherProps(props),
-        ptCallbacks.ptm('root')
+        TreeTableBase.getOtherProps(props)
     );
 
     return (

--- a/components/lib/tristatecheckbox/TriStateCheckbox.js
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.js
@@ -146,13 +146,13 @@ export const TriStateCheckbox = React.memo(
         );
 
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 className: classNames(props.className, cx('root', { context })),
                 style: props.style,
                 'data-p-disabled': props.disabled
             },
-            TriStateCheckboxBase.getOtherProps(props),
-            ptm('root')
+            TriStateCheckboxBase.getOtherProps(props)
         );
 
         const inputProps = mergeProps(

--- a/components/lib/virtualscroller/VirtualScroller.js
+++ b/components/lib/virtualscroller/VirtualScroller.js
@@ -781,6 +781,7 @@ export const VirtualScroller = React.memo(
         const content = createContent();
         const spacer = createSpacer();
         const rootProps = mergeProps(
+            ptm('root'),
             {
                 ref: elementRef,
                 className,
@@ -788,8 +789,7 @@ export const VirtualScroller = React.memo(
                 style: props.style,
                 onScroll: (e) => onScroll(e)
             },
-            VirtualScrollerBase.getOtherProps(props),
-            ptm('root')
+            VirtualScrollerBase.getOtherProps(props)
         );
 
         return (


### PR DESCRIPTION
## Summary

- move root passthrough props before component props in 94 components
- preserve user-supplied Tailwind classes when `tailwind-merge` is enabled
- update Button snapshots for the corrected passthrough section metadata

## Root cause

Root passthrough props were merged last, allowing global theme classes to override a component's `className`. With `tailwind-merge`, conflicting utilities such as `hidden` could therefore be discarded.

## Provenance

Migrates [primefaces/primereact#8156](https://github.com/primefaces/primereact/pull/8156). Mantle-specific `InputText` and `MultiStateCheckbox` additions were retained while applying the same merge order.

Created By: @orelus

Fixes #195

## Validation

- `npx eslint` on all changed component files
- `git diff --check`
- `npm run test:check` — 26 suites passed, 270 tests passed