### PR TITLE
fix(Calendar): navigate overlay days across rows

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1293,7 +1293,36 @@ export const Calendar = React.memo(
                             navigateToMonth(true, groupIndex, event);
                         }
                     } else {
-                        navigateToMonth(true, groupIndex, event);
+                        let prevRow = cell.parentElement.previousElementSibling;
+
+                        if (prevRow) {
+                            const lastCellIndex = prevRow.children.length - 1;
+                            const lastCell = prevRow.children[lastCellIndex];
+                            let focusCell = lastCell.children[0];
+
+                            if (!DomHandler.getAttribute(focusCell, 'data-p-disabled')) {
+                                focusCell.tabIndex = '0';
+                                focusCell.focus();
+                            } else {
+                                const prevRowCells = Array.from(prevRow.children).reverse();
+                                let hasPrevFocusableDate = prevRowCells.find((el) => {
+                                    let focusCell = el.children[0];
+
+                                    return !DomHandler.getAttribute(focusCell, 'data-p-disabled');
+                                });
+
+                                if (hasPrevFocusableDate) {
+                                    let focusCell = hasPrevFocusableDate.children[0];
+
+                                    focusCell.tabIndex = '0';
+                                    focusCell.focus();
+                                } else {
+                                    navigateToMonth(true, groupIndex, event);
+                                }
+                            }
+                        } else {
+                            navigateToMonth(true, groupIndex, event);
+                        }
                     }
 
                     event.preventDefault();
@@ -1307,6 +1336,7 @@ export const Calendar = React.memo(
                     if (nextCell) {
                         const cells = Array.from(cell.parentElement.children);
                         const nextCells = cells.slice(cellIndex + 1);
+
                         let hasNextFocusableDate = nextCells.find((el) => {
                             let focusCell = el.children[0];
 
@@ -1322,7 +1352,35 @@ export const Calendar = React.memo(
                             navigateToMonth(false, groupIndex, event);
                         }
                     } else {
-                        navigateToMonth(false, groupIndex, event);
+                        let nextRow = cell.parentElement.nextElementSibling;
+
+                        if (nextRow) {
+                            const firstCell = nextRow.children[0];
+                            let focusCell = firstCell.children[0];
+
+                            if (!DomHandler.getAttribute(focusCell, 'data-p-disabled')) {
+                                focusCell.tabIndex = '0';
+                                focusCell.focus();
+                            } else {
+                                const nextRowCells = Array.from(nextRow.children);
+                                let hasNextFocusableDate = nextRowCells.find((el) => {
+                                    let focusCell = el.children[0];
+
+                                    return !DomHandler.getAttribute(focusCell, 'data-p-disabled');
+                                });
+
+                                if (hasNextFocusableDate) {
+                                    let focusCell = hasNextFocusableDate.children[0];
+
+                                    focusCell.tabIndex = '0';
+                                    focusCell.focus();
+                                } else {
+                                    navigateToMonth(false, groupIndex, event);
+                                }
+                            }
+                        } else {
+                            navigateToMonth(false, groupIndex, event);
+                        }
                     }
 
                     event.preventDefault();


### PR DESCRIPTION
## Summary

- move Calendar overlay focus to the adjacent week row when ArrowLeft or ArrowRight reaches a row boundary
- retain the existing month-navigation fallback when no focusable date exists in that row

## Root cause

At a calendar-row boundary, horizontal arrow navigation immediately changed the month. This made keyboard navigation skip the next or previous week row.

## Provenance

Migrates the explicitly selected [primefaces/primereact#7933](https://github.com/primefaces/primereact/pull/7933), not the alternate upstream PR.

Created By: @bogdan-dimoiu

Fixes #192

## Validation

- `npx eslint components/lib/calendar/Calendar.js`
- `git diff --check`
- `npx jest components/lib/calendar/Calendar.spec.js --runInBand --silent`