### PR TITLE
Removed deprecation for MantleUI

### DIFF
--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -678,7 +678,7 @@ export interface MantleUIPTOptions {
 }
 
 /**
- * @deprecated since version 9.6.0. Use MantleContext instead.
+ * MantleUI for APIOptions (or use MantleContext instead).
  */
 declare const MantleUI: APIOptions;
 


### PR DESCRIPTION
Removed deprecation and updated notice for MantleUI to reference MantleContext.
