### PR TITLE
Add version metadata to subpackages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,27 @@ var gulp = require('gulp'),
     concat = require('gulp-concat'),
     uglifycss = require('gulp-uglifycss'),
     rename = require('gulp-rename'),
-    flatten = require('gulp-flatten');
+    flatten = require('gulp-flatten'),
+    Transform = require('stream').Transform,
+    rootPackage = require('./package.json');
+
+function addPackageVersion() {
+    return new Transform({
+        objectMode: true,
+        transform: function (file, encoding, callback) {
+            try {
+                var packageJson = JSON.parse(file.contents.toString());
+
+                packageJson.version = rootPackage.version;
+                file.contents = Buffer.from(JSON.stringify(packageJson, null, 4) + '\n');
+
+                callback(null, file);
+            } catch (error) {
+                callback(error);
+            }
+        }
+    });
+}
 
 /** @deprecated */
 gulp.task('build-css', function () {
@@ -76,7 +96,7 @@ gulp.task('copy-d.ts', function () {
 });
 
 gulp.task('copy-package.json', function () {
-    return gulp.src(process.env.INPUT_DIR + '**/package.json').pipe(gulp.dest('./' + process.env.OUTPUT_DIR));
+    return gulp.src(process.env.INPUT_DIR + '**/package.json').pipe(addPackageVersion()).pipe(gulp.dest('./' + process.env.OUTPUT_DIR));
 });
 
 gulp.task('copy-bin', function () {


### PR DESCRIPTION
## Summary

- add the root package version to every subpackage `package.json` during the packaging copy step
- allow Module Federation to infer a version for `@mantle-ui/react/*` shared modules

## Root cause

Subpackage manifests were copied unchanged and did not contain a `version` field, even though the root package manifest does.

##Provenance

Based on https://github.com/Mantle-UI/mantle-ui/issues/187, which carries over the report from https://github.com/primefaces/primereact/issues/8065. The fix updates Mantle’s packaging copy step so every generated subpackage manifest includes the root package version.

Created By: @CompartMJU

Fixes #187 

## Validation

- `npx gulp copy-package.json` with `INPUT_DIR=components/lib/` and a temporary output directory
- verified all 163 copied manifests and confirmed `utils/package.json` contains version `10.10.6`