### PR TITLE
Add accessible name to ListBox

### DIFF
--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FilterService, MantleContext, localeOption } from '../api/Api';
+import { ariaLabel, FilterService, MantleContext, localeOption } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
 import { useMergeProps, useMountEffect } from '../hooks/Hooks';
 import { Tooltip } from '../tooltip/Tooltip';
@@ -822,6 +822,7 @@ export const ListBox = React.memo(
                                     className: ptCallbacks.cx('list', { options }),
                                     role: 'listbox',
                                     tabIndex: '-1',
+                                    'aria-label': ariaLabel('listLabel'),
                                     'aria-multiselectable': props.multiple,
                                     onFocus: onListFocus,
                                     onBlur: onListBlur,
@@ -846,6 +847,7 @@ export const ListBox = React.memo(
                     ref: listRef,
                     className: ptCallbacks.cx('list'),
                     role: 'listbox',
+                    'aria-label': ariaLabel('listLabel'),
                     'aria-multiselectable': props.multiple,
                     tabIndex: '-1',
                     onFocus: onListFocus,

--- a/components/lib/listbox/ListBox.spec.js
+++ b/components/lib/listbox/ListBox.spec.js
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { MantleProvider } from '../api/Api';
+import { ListBox } from './ListBox';
+
+describe('ListBox', () => {
+    test('provides a default accessible name for the listbox', () => {
+        render(
+            <MantleProvider>
+                <ListBox options={['Amsterdam']} />
+            </MantleProvider>
+        );
+
+        expect(screen.getByRole('listbox', { name: 'Option List' })).toBeInTheDocument();
+    });
+
+    test('uses an explicit accessible name when provided', () => {
+        render(
+            <MantleProvider>
+                <ListBox aria-label="Cities" options={['Amsterdam']} />
+            </MantleProvider>
+        );
+
+        expect(screen.getByRole('listbox', { name: 'Cities' })).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

- give ListBox’s `role="listbox"` a localized default accessible name (`Option List`)
- preserve consumer-provided `aria-label` and `aria-labelledby` values
- cover the fallback and explicit-label behavior with focused tests

## Root cause

ListBox forwarded custom ARIA attributes but rendered an unnamed listbox when no label was supplied, which fails the ARIA accessible-name requirement.

Fixes #138.

## Validation

- `npx jest components/lib/listbox/ListBox.spec.js --watchAll=false --silent --runInBand`
- `npm run format:check -- --config .prettierrc.json`