### PR TITLE
Render ReactNode tooltip content

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -64,10 +64,6 @@ export const Tooltip = React.memo(
             when: visibleState
         });
 
-        const isTargetContentEmpty = (target) => {
-            return !(props.content || getTargetOption(target, 'tooltip'));
-        };
-
         const isContentEmpty = (target) => {
             return !(props.content || getTargetOption(target, 'tooltip') || props.children);
         };
@@ -132,16 +128,10 @@ export const Tooltip = React.memo(
         };
 
         const updateText = (target, callback) => {
-            if (textRef.current) {
-                const content = getTargetOption(target, 'tooltip') || props.content;
+            const content = getTargetOption(target, 'tooltip') || props.content || props.children;
 
-                if (content) {
-                    textRef.current.innerHTML = ''; // remove children
-                    textRef.current.appendChild(document.createTextNode(content));
-                    callback();
-                } else if (props.children) {
-                    callback();
-                }
+            if (content) {
+                callback();
             }
         };
 
@@ -518,7 +508,7 @@ export const Tooltip = React.memo(
         }));
 
         const createElement = () => {
-            const empty = isTargetContentEmpty(currentTargetRef.current);
+            const content = getTargetOption(currentTargetRef.current, 'tooltip') || props.content || props.children;
             const rootProps = mergeProps(
                 ptm('root'),
                 {
@@ -552,7 +542,7 @@ export const Tooltip = React.memo(
                 <div ref={elementRef} {...rootProps}>
                     <div {...arrowProps} />
                     <div ref={textRef} {...textProps}>
-                        {empty && props.children}
+                        {content}
                     </div>
                 </div>
             );

--- a/components/lib/tooltip/Tooltip.spec.js
+++ b/components/lib/tooltip/Tooltip.spec.js
@@ -71,6 +71,26 @@ describe('Tooltip', () => {
         fireEvent.mouseLeave(input);
         expect(screen.queryByText(tooltipText)).toBeNull();
     });
+    test('when using ReactNode content it renders the node', async () => {
+        // Arrange
+        const { container } = render(
+            <MantleProvider>
+                <Tooltip target=".tooltip-target" content={<strong>Rich tooltip content</strong>} />
+                <button className="tooltip-target" type="button">
+                    Target
+                </button>
+            </MantleProvider>
+        );
+        const target = container.getElementsByClassName('tooltip-target')[0];
+
+        // Act
+        fireEvent.mouseEnter(target);
+
+        // Assert
+        await waitFor(() => screen.getByText('Rich tooltip content'));
+        expect(screen.getByText('Rich tooltip content')).toBeVisible();
+        expect(screen.queryByText('[object Object]')).toBeNull();
+    });
     test('when using tooltip with event focus it is displayed on events focus and blur', async () => {
         // Arrange
         const tooltipText = /Focus Blur/i;


### PR DESCRIPTION
## Summary

- render Tooltip `content` through React instead of converting it to a DOM text node
- retain support for `data-pr-tooltip`, string content, and children
- add a regression test for ReactNode content

## Root cause

Tooltip used `document.createTextNode(content)`, which coerced React elements to `[object Object]` even though `content` is typed as `ReactNode`.

Fixes #159.

## Validation

- `npx jest components/lib/tooltip/Tooltip.spec.js --watchAll=false --silent --runInBand`
- `npm run format:check -- --config .prettierrc.json`