### PR TITLE
docs: use Mantle logo favicon

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -5,6 +5,7 @@ import Menu from '@/components/layout/menu';
 import Topbar from '@/components/layout/topbar';
 import { MantleContext } from '@/components/lib/api/MantleContext';
 import { DomHandler, classNames } from '@/components/lib/utils/Utils';
+import { withBasePath } from '@/components/utils/utils';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useContext, useEffect, useState } from 'react';
@@ -75,7 +76,7 @@ export default function Layout({ children }) {
                 <meta property="og:description" content="Mantle UI is a flexible and accessible React component library." />
                 <meta property="og:image" content="/images/mantle-ui-logo.png" />
                 <meta property="og:ttl" content="604800" />
-                <link rel="icon" href="/favicon.ico" type="image/x-icon" />
+                <link rel="icon" href={withBasePath('/favicon.svg')} type="image/svg+xml" />
             </Head>
             <Topbar showConfigurator showMenuButton onMenuButtonClick={() => setSidebarActive(true)} onConfigButtonClick={() => setConfigActive(true)} onDarkSwitchClick={toggleDarkMode} />
             <div className={classNames('layout-mask', { 'layout-mask-active': sidebarActive })} onClick={() => setSidebarActive(false)} />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,7 +7,7 @@ export default function Document() {
             <Head>
                 {/* eslint-disable */}
                 <meta name="algolia-site-verification" content="D315CFBBFC16F186" />
-                <link href={withBasePath('/favicon.ico')} rel="icon" type="image/x-icon"></link>
+                <link href={withBasePath('/favicon.svg')} rel="icon" type="image/svg+xml"></link>
                 <link id="theme-link" href={withBasePath('/themes/lara-dark-cyan/theme.css')} rel="stylesheet"></link>
                 <link id="home-table-link" href={withBasePath('/styles/landing/themes/lara-dark-cyan/theme.css')} rel="stylesheet"></link>
                 <link rel="stylesheet" href={withBasePath('/styles/flags.css')}></link>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 310 300" role="img" aria-label="Mantle UI M logo icon">
+    <defs>
+        <linearGradient id="blueGrad" x1="38" y1="15" x2="291" y2="206" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stop-color="#5F66F6" />
+            <stop offset="100%" stop-color="#4E57E8" />
+        </linearGradient>
+        <linearGradient id="navyGrad" x1="90" y1="123" x2="241" y2="229" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stop-color="#33415C" />
+            <stop offset="100%" stop-color="#243455" />
+        </linearGradient>
+        <linearGradient id="tealGrad" x1="39" y1="187" x2="290" y2="276" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stop-color="#18C7BA" />
+            <stop offset="100%" stop-color="#14B8A6" />
+        </linearGradient>
+    </defs>
+    <path fill="url(#blueGrad)" d="M38 15v191l40-28 1-78 85 60 86-60 2 76 39 30V16l-127 89z" />
+    <path fill="url(#navyGrad)" d="M90 123l-1 51 76 55 76-54v-52l-76 53z" />
+    <path fill="url(#tealGrad)" d="M39 277v-57l48-33 39 28zM205 216l40-29 45 33v56z" />
+</svg>


### PR DESCRIPTION
## Summary
- add the supplied Mantle logo as the SVG favicon
- use it in the documentation page heads with GitHub Pages base-path support

## Verification
- npm run build:docs