### PR TITLE
fix(docs): format API default values

### DIFF
--- a/api-scripts/build-apidoc.js
+++ b/api-scripts/build-apidoc.js
@@ -51,6 +51,10 @@ const LIBRARY_DISPLAY_NAME = 'Mantle UI';
             return text.replace(/&#123;/g, '{').replace(/&#125;/g, '}');
         };
 
+        const parseDefaultValue = (text) => {
+            return parseText(text).replace(/^```[^\r\n]*\r?\n([\s\S]*?)\r?\n```$/, '$1');
+        };
+
         project.children.forEach((module) => {
             const { name, comment } = module;
 
@@ -147,7 +151,7 @@ const LIBRARY_DISPLAY_NAME = 'Mantle UI';
                                             optional: prop.flags.isOptional,
                                             readonly: prop.flags.isReadonly,
                                             type: prop.type.toString(),
-                                            default: prop.comment && prop.comment.getTag('@defaultValue') ? parseText(prop.comment.getTag('@defaultValue').content[0].text) : '', // TODO: Check
+                                            default: prop.comment && prop.comment.getTag('@defaultValue') ? parseDefaultValue(prop.comment.getTag('@defaultValue').content[0].text) : '', // TODO: Check
                                             description: prop.comment && prop.comment.summary.map((s) => parseText(s.text || '')).join(' '),
                                             deprecated: prop.comment && prop.comment.getTag('@deprecated') ? parseText(prop.comment.getTag('@deprecated').content[0].text) : undefined
                                         });
@@ -215,7 +219,7 @@ const LIBRARY_DISPLAY_NAME = 'Mantle UI';
                                 optional: prop.flags.isOptional,
                                 readonly: prop.flags.isReadonly,
                                 type: prop.type.toString(),
-                                default: prop.comment && prop.comment.getTag('@defaultValue') ? prop.comment.getTag('@defaultValue').content[0].text : '', // TODO: Check
+                                default: prop.comment && prop.comment.getTag('@defaultValue') ? parseDefaultValue(prop.comment.getTag('@defaultValue').content[0].text) : '', // TODO: Check
                                 description: prop.comment && prop.comment.summary.map((s) => s.text || '').join(' ')
                             });
                         });

--- a/api-scripts/build-webtypes.js
+++ b/api-scripts/build-webtypes.js
@@ -78,6 +78,10 @@ const webTypes = {
             return text.replace(/&#123;/g, '{').replace(/&#125;/g, '}');
         };
 
+        const parseDefaultValue = (text) => {
+            return parseText(text).replace(/^```[^\r\n]*\r?\n([\s\S]*?)\r?\n```$/, '$1');
+        };
+
         project.children.forEach((module) => {
             const { name, comment } = module;
 
@@ -169,7 +173,7 @@ const webTypes = {
                                 if (!prop.inheritedFrom || (prop.inheritedFrom && !prop.inheritedFrom.toString().startsWith('Omit.data-pr-'))) {
                                     props.push({
                                         name: prop.name,
-                                        default: prop.comment && prop.comment.getTag('@defaultValue') ? parseText(prop.comment.getTag('@defaultValue').content[0].text) : 'null', // TODO: Check
+                                        default: prop.comment && prop.comment.getTag('@defaultValue') ? parseDefaultValue(prop.comment.getTag('@defaultValue').content[0].text) : 'null', // TODO: Check
                                         description: prop.comment && prop.comment.summary.map((s) => parseText(s.text || '')).join(' '),
                                         value: {
                                             kind: 'expression',
@@ -235,7 +239,7 @@ const webTypes = {
                                 optional: prop.flags.isOptional,
                                 readonly: prop.flags.isReadonly,
                                 type: prop.type.toString(),
-                                default: prop.comment && prop.comment.getTag('@defaultValue') ? prop.comment.getTag('@defaultValue').content[0].text : '', // TODO: Check
+                                default: prop.comment && prop.comment.getTag('@defaultValue') ? parseDefaultValue(prop.comment.getTag('@defaultValue').content[0].text) : '', // TODO: Check
                                 description: prop.comment && prop.comment.summary.map((s) => s.text || '').join(' ')
                             });
                         });

--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -48,7 +48,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the tab is disabled."
                         },
                         {
@@ -112,7 +112,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the element in tabbing order."
                         },
                         {
@@ -120,7 +120,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -183,7 +183,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, multiple tabs can be activated at the same time."
                         },
                         {
@@ -3656,7 +3656,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -3664,7 +3664,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -3672,7 +3672,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, highlights the first item in the list by default."
                         },
                         {
@@ -3696,7 +3696,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay between keystrokes to wait before sending a query."
                         },
                         {
@@ -3704,7 +3704,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -3712,7 +3712,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a button next to the input field when enabled."
                         },
                         {
@@ -3720,7 +3720,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nChoose\n```",
+                            "default": "Choose",
                             "description": "ARIA label for the dropdown button. Defaults to placeholder then Locale \"choose\" label."
                         },
                         {
@@ -3728,7 +3728,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Focus the input field when the dropdown button is clicked if enabled."
                         },
                         {
@@ -3744,7 +3744,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"blank\" | \"current\"",
-                            "default": "```ts\nblank\n```",
+                            "default": "blank",
                             "description": "Specifies the behavior dropdown button. Default \"blank\" mode sends an empty string and \"current\" mode sends the input value."
                         },
                         {
@@ -3752,7 +3752,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nNo results found.\n```",
+                            "default": "No results found.",
                             "description": "Text to display when there is no data. Defaults to global value in i18n translation configuration."
                         },
                         {
@@ -3768,7 +3768,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, autocomplete clears the manual input if it does not match of the suggestions to force only accepting values from the suggestions."
                         },
                         {
@@ -3816,7 +3816,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -3848,7 +3848,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Minimum number of characters to initiate a search."
                         },
                         {
@@ -3856,7 +3856,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "M",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies if multiple values can be selected."
                         },
                         {
@@ -3944,7 +3944,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the input cannot be typed."
                         },
                         {
@@ -3960,7 +3960,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field must be filled out before submitting the form."
                         },
                         {
@@ -3968,7 +3968,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n200px\n```",
+                            "default": "200px",
                             "description": "Maximum height of the suggestions panel."
                         },
                         {
@@ -3992,7 +3992,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show the empty message or not."
                         },
                         {
@@ -4064,7 +4064,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -4080,7 +4080,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         },
                         {
@@ -4696,7 +4696,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\navatar\n```",
+                            "default": "avatar",
                             "description": "It specifies an alternate text for an image, if the image cannot be displayed."
                         },
                         {
@@ -4704,7 +4704,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\ndefault\n```",
+                            "default": "default",
                             "description": "Defines a fallback image or URL if the main image fails to load. If \"default\" will fallback to label then icon."
                         },
                         {
@@ -4736,7 +4736,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"square\" | \"circle\"",
-                            "default": "```ts\nsquare\n```",
+                            "default": "square",
                             "description": "Shape of the element."
                         },
                         {
@@ -4744,7 +4744,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"normal\" | \"large\" | \"xlarge\"",
-                            "default": "```ts\nnormal\n```",
+                            "default": "normal",
                             "description": "Size of the element."
                         },
                         {
@@ -4760,7 +4760,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -4942,7 +4942,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -5042,7 +5042,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"info\" | \"warning\" | \"success\" | \"secondary\" | \"danger\" | \"contrast\" | null",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Severity type of the badge."
                         },
                         {
@@ -5050,7 +5050,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"normal\" | \"large\" | \"xlarge\" | null",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Size of the badge, valid options are \"large\" and \"xlarge\"."
                         },
                         {
@@ -5058,7 +5058,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -5159,7 +5159,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -5167,7 +5167,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -5175,7 +5175,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Controls the blocked state."
                         },
                         {
@@ -5207,7 +5207,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the whole document gets blocked."
                         },
                         {
@@ -5239,7 +5239,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -5410,7 +5410,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -5559,7 +5559,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -5575,7 +5575,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nleft\n```",
+                            "default": "left",
                             "description": "Position of the icon, valid values are \"left\", \"right\", \"top\" and \"bottom\"."
                         },
                         {
@@ -5591,7 +5591,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a link style to the button."
                         },
                         {
@@ -5599,7 +5599,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Display loading icon of the button"
                         },
                         {
@@ -5615,7 +5615,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a border class without a background initially."
                         },
                         {
@@ -5623,7 +5623,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a plain textual class to the button without a background initially."
                         },
                         {
@@ -5647,7 +5647,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a shadow to indicate elevation."
                         },
                         {
@@ -5655,7 +5655,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a circular border radius to the button."
                         },
                         {
@@ -5679,7 +5679,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a textual class to the button without a background initially."
                         },
                         {
@@ -5703,7 +5703,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -5711,7 +5711,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When present, it specifies that the element should be visible."
                         }
                     ]
@@ -6024,7 +6024,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -6048,7 +6048,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -6056,7 +6056,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -6064,7 +6064,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -6088,7 +6088,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\np-secondary-button\n```",
+                            "default": "p-secondary-button",
                             "description": "Style class of the clear button."
                         },
                         {
@@ -6096,7 +6096,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmm/dd/yy\n```",
+                            "default": "mm/dd/yy",
                             "description": "Format of the date."
                         },
                         {
@@ -6112,7 +6112,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, disables the component."
                         },
                         {
@@ -6144,7 +6144,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to hide the overlay on date selection when showTime is enabled."
                         },
                         {
@@ -6160,7 +6160,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"12\" | \"24\"",
-                            "default": "```ts\n24\n```",
+                            "default": "24",
                             "description": "Specifies 12 or 24 hour format."
                         },
                         {
@@ -6176,7 +6176,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"right\"",
-                            "default": "```ts\nright\n```",
+                            "default": "right",
                             "description": "Icon position of the calendar button."
                         },
                         {
@@ -6200,7 +6200,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, displays the calendar as inline instead of an overlay."
                         },
                         {
@@ -6240,7 +6240,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -6248,7 +6248,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Keep invalid value when input blur."
                         },
                         {
@@ -6256,7 +6256,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nen\n```",
+                            "default": "en",
                             "description": "Used to display the values ​​of the locale object defined in the Locale API."
                         },
                         {
@@ -6272,7 +6272,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n_\n```",
+                            "default": "_",
                             "description": "Placeholder character in mask."
                         },
                         {
@@ -6304,7 +6304,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the month should be rendered as a dropdown instead of text."
                         },
                         {
@@ -6328,7 +6328,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Number of months to display."
                         },
                         {
@@ -6384,7 +6384,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, prevents entering the date manually with keyboard."
                         },
                         {
@@ -6392,7 +6392,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field must be filled out before submitting the form."
                         },
                         {
@@ -6400,7 +6400,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "TMode",
-                            "default": "```ts\nsingle\n```",
+                            "default": "single",
                             "description": "Specifies the selection mode either \"single\", \"range\", or \"multiple\";"
                         },
                         {
@@ -6408,7 +6408,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether days in other months shown before or after the current month are selectable. This only applies if the showOtherMonths option is set to true."
                         },
                         {
@@ -6416,7 +6416,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n+10\n```",
+                            "default": "+10",
                             "description": "The cutoff year for determining the century for a date."
                         },
                         {
@@ -6424,7 +6424,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display today and clear buttons at the footer"
                         },
                         {
@@ -6432,7 +6432,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, displays a button with icon next to input."
                         },
                         {
@@ -6440,7 +6440,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show the milliseconds in time picker."
                         },
                         {
@@ -6448,7 +6448,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Controls whether navigation beyond minimum and maximum dates is restricted. When true, navigation is limited to the min/max date range."
                         },
                         {
@@ -6456,7 +6456,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When disabled, datepicker will not be visible with input focus."
                         },
                         {
@@ -6464,7 +6464,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display dates in other months (non-selectable) at the start or end of the current month. To make these days selectable use the selectOtherMonths option."
                         },
                         {
@@ -6472,7 +6472,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show the seconds in time picker."
                         },
                         {
@@ -6480,7 +6480,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display timepicker."
                         },
                         {
@@ -6488,7 +6488,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, calendar will show week numbers."
                         },
                         {
@@ -6496,7 +6496,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Hours to change per step."
                         },
                         {
@@ -6504,7 +6504,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Milliseconds to change per step."
                         },
                         {
@@ -6512,7 +6512,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Minutes to change per step."
                         },
                         {
@@ -6520,7 +6520,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Seconds to change per step."
                         },
                         {
@@ -6544,7 +6544,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display timepicker only."
                         },
                         {
@@ -6552,7 +6552,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\np-secondary-button\n```",
+                            "default": "p-secondary-button",
                             "description": "Style class of the today button."
                         },
                         {
@@ -6576,7 +6576,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, calendar overlay is displayed as optimized for touch devices."
                         },
                         {
@@ -6592,7 +6592,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -6600,7 +6600,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "Nullable<TValue>",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Value of the component."
                         },
                         {
@@ -6608,7 +6608,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         },
                         {
@@ -6616,7 +6616,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"month\" | \"year\" | \"date\"",
-                            "default": "```ts\ndate\n```",
+                            "default": "date",
                             "description": "Type of view to display."
                         },
                         {
@@ -6632,7 +6632,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the overlay."
                         },
                         {
@@ -6640,7 +6640,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the year should be rendered as a dropdown instead of text."
                         },
                         {
@@ -8546,7 +8546,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -8699,7 +8699,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if scrolling would be infinite."
                         },
                         {
@@ -8755,7 +8755,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Number of items to scroll."
                         },
                         {
@@ -8763,7 +8763,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Number of items per page."
                         },
                         {
@@ -8771,7 +8771,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Specifies the layout of the component, valid values are \"horizontal\" and \"vertical\"."
                         },
                         {
@@ -8819,7 +8819,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display indicator container."
                         },
                         {
@@ -8827,7 +8827,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display navigation buttons in container."
                         },
                         {
@@ -8835,7 +8835,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -8851,7 +8851,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n300px\n```",
+                            "default": "300px",
                             "description": "Height of the viewport in vertical layout."
                         }
                     ]
@@ -9197,7 +9197,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -9213,7 +9213,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -9253,7 +9253,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -9293,7 +9293,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -9309,7 +9309,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Display loading icon."
                         },
                         {
@@ -9421,7 +9421,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n400px\n```",
+                            "default": "400px",
                             "description": "Maximum height of the options panel on responsive mode."
                         },
                         {
@@ -9429,7 +9429,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a clear icon is displayed to clear the value."
                         },
                         {
@@ -9461,7 +9461,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -9477,7 +9477,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -10156,7 +10156,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -10266,7 +10266,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -10274,7 +10274,7 @@
                             "optional": false,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies whether a checkbox should be checked or not."
                         },
                         {
@@ -10298,7 +10298,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element value cannot be altered."
                         },
                         {
@@ -10306,7 +10306,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "any",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Value in unchecked state."
                         },
                         {
@@ -10346,7 +10346,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -10378,7 +10378,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the value cannot be changed."
                         },
                         {
@@ -10386,7 +10386,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field must be filled out before submitting the form."
                         },
                         {
@@ -10402,7 +10402,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Index of the element in tabbing order."
                         },
                         {
@@ -10426,7 +10426,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "any",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Value in checked state."
                         },
                         {
@@ -10434,7 +10434,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -10450,7 +10450,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -10770,7 +10770,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display a remove icon."
                         },
                         {
@@ -10794,7 +10794,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -10989,7 +10989,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to add an item when the input loses focus."
                         },
                         {
@@ -10997,7 +10997,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to allow duplicate values or not."
                         },
                         {
@@ -11013,7 +11013,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -11029,7 +11029,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -11053,7 +11053,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -11109,7 +11109,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be read-only."
                         },
                         {
@@ -11117,7 +11117,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean | ((options: ChipsRemovableOptions) => boolean)",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether an item is removable."
                         },
                         {
@@ -11157,7 +11157,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -11173,7 +11173,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -11523,7 +11523,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -11531,7 +11531,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -11547,7 +11547,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nff0000\n```",
+                            "default": "ff0000",
                             "description": "Default color to display when value is null."
                         },
                         {
@@ -11555,7 +11555,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"rgb\" | \"hex\" | \"hsb\"",
-                            "default": "```ts\nhex\n```",
+                            "default": "hex",
                             "description": "Format to use in value binding."
                         },
                         {
@@ -11563,7 +11563,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display as an overlay or not."
                         },
                         {
@@ -11659,7 +11659,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -12001,7 +12001,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled and cellEditorValidator is set, force to call cellEditorValidator\nbefore cell editor is closed. If cellEditorValidator returns false, editor stays open."
                         },
                         {
@@ -12009,7 +12009,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nclick\n```",
+                            "default": "click",
                             "description": "Event to trigger the validation, possible values are \"click\" and \"blur\"."
                         },
                         {
@@ -12065,7 +12065,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to exclude from global filtering or not."
                         },
                         {
@@ -12073,7 +12073,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean | ((data: any, options: ColumnBodyOptions) => boolean)",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays an icon to toggle row expansion."
                         },
                         {
@@ -12081,7 +12081,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines whether the column is exported or not."
                         },
                         {
@@ -12113,7 +12113,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if a column can be filtered."
                         },
                         {
@@ -12233,7 +12233,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\ntext\n```",
+                            "default": "text",
                             "description": "Type of the filter input field."
                         },
                         {
@@ -12265,7 +12265,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the column is fixed in horizontal scrolling or not."
                         },
                         {
@@ -12313,7 +12313,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the column is rendered."
                         },
                         {
@@ -12321,7 +12321,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n2\n```",
+                            "default": "2",
                             "description": "Maximum number of constraints for a column filter."
                         },
                         {
@@ -12361,7 +12361,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean | ((data: any, options: ColumnBodyOptions) => boolean)",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays icons to edit row."
                         },
                         {
@@ -12369,7 +12369,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether this column displays an icon to reorder the rows."
                         },
                         {
@@ -12401,7 +12401,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, a button is displayed to add more rules."
                         },
                         {
@@ -12409,7 +12409,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Displays a button to apply the column filtering."
                         },
                         {
@@ -12417,7 +12417,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Displays a button to clear the column filtering."
                         },
                         {
@@ -12425,7 +12425,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the match modes selector."
                         },
                         {
@@ -12433,7 +12433,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display the filter overlay."
                         },
                         {
@@ -12441,7 +12441,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the match modes selector and match operator selector."
                         },
                         {
@@ -12449,7 +12449,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, match all and match any operator selector is displayed."
                         },
                         {
@@ -12457,7 +12457,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if a column is sortable."
                         },
                         {
@@ -12465,7 +12465,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the data of columns with this property cannot be sorted or changed by the user."
                         },
                         {
@@ -12489,7 +12489,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -14155,7 +14155,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -14352,7 +14352,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nYes\n```",
+                            "default": "Yes",
                             "description": "Label of the accept button."
                         },
                         {
@@ -14360,7 +14360,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -14376,7 +14376,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -14384,7 +14384,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether background scroll should be blocked when dialog is visible."
                         },
                         {
@@ -14416,7 +14416,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the dialog can be closed by clicking the close icon, pressing escape key or clicking the modal background."
                         },
                         {
@@ -14432,7 +14432,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the dialog."
                         },
                         {
@@ -14464,7 +14464,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\naccept\n```",
+                            "default": "accept",
                             "description": "Element to receive the focus when the dialog gets visible, valid values are \"accept\" and \"reject\"."
                         },
                         {
@@ -14472,7 +14472,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies if clicking the modal background should hide the dialog."
                         },
                         {
@@ -14480,7 +14480,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables dragging to change the position using header."
                         },
                         {
@@ -14488,7 +14488,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, first button receives focus on show."
                         },
                         {
@@ -14560,7 +14560,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Keeps dialog in the viewport."
                         },
                         {
@@ -14584,7 +14584,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the dialog can be displayed full screen."
                         },
                         {
@@ -14592,7 +14592,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the dialog is initially displayed full screen."
                         },
                         {
@@ -14624,7 +14624,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Minimum value for the left coordinate of dialog in dragging."
                         },
                         {
@@ -14632,7 +14632,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Minimum value for the top coordinate of dialog in dragging."
                         },
                         {
@@ -14640,7 +14640,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines if background should be blocked when dialog is displayed."
                         },
                         {
@@ -14718,7 +14718,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"center\" | \"left\" | \"top\" | \"bottom\" | \"right\" | \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\"",
-                            "default": "```ts\ncenter\n```",
+                            "default": "center",
                             "description": "Position of the dialog, options are \"center\", \"top\", \"bottom\", \"left\", \"right\", \"top-left\", \"top-right\", \"bottom-left\" or \"bottom-right\"."
                         },
                         {
@@ -14758,7 +14758,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nNo\n```",
+                            "default": "No",
                             "description": "Label of the reject button."
                         },
                         {
@@ -14766,7 +14766,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables resizing of the content."
                         },
                         {
@@ -14774,7 +14774,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled dialog is displayed in RTL direction."
                         },
                         {
@@ -14782,7 +14782,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the close icon is displayed in the header."
                         },
                         {
@@ -14790,7 +14790,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the header or not."
                         },
                         {
@@ -14822,7 +14822,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -14830,7 +14830,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the confirm dialog."
                         }
                     ]
@@ -15184,7 +15184,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nYes\n```",
+                            "default": "Yes",
                             "description": "Label of the accept button."
                         },
                         {
@@ -15192,7 +15192,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -15216,7 +15216,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the popup."
                         },
                         {
@@ -15232,7 +15232,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\naccept\n```",
+                            "default": "accept",
                             "description": "Element to receive the focus when the dialog gets visible, valid values are \"accept\" and \"reject\"."
                         },
                         {
@@ -15240,7 +15240,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables to hide the popup when outside is clicked."
                         },
                         {
@@ -15304,7 +15304,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nNo\n```",
+                            "default": "No",
                             "description": "Label of the reject button."
                         },
                         {
@@ -15344,7 +15344,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -15352,7 +15352,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the confirm popup."
                         }
                     ]
@@ -15721,7 +15721,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -15745,7 +15745,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -15753,7 +15753,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -15777,7 +15777,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Attaches the menu to document instead of a particular item."
                         },
                         {
@@ -15801,7 +15801,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n400px\n```",
+                            "default": "400px",
                             "description": "Maximum height of the options panel on responsive mode."
                         },
                         {
@@ -15825,7 +15825,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -16115,7 +16115,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0.9\n```",
+                            "default": "0.9",
                             "description": "Number of buffer size."
                         },
                         {
@@ -16131,7 +16131,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: DataScrollerProps) => ReactNode)",
-                            "default": "```ts\nNo records found\n```",
+                            "default": "No records found",
                             "description": "Text to display when there is no data."
                         },
                         {
@@ -16155,7 +16155,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if the event target to listen the scroll event is the element itself."
                         },
                         {
@@ -16163,7 +16163,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if data is loaded and interacted with in lazy manner."
                         },
                         {
@@ -16211,7 +16211,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -16561,7 +16561,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show it even there is only one page."
                         },
                         {
@@ -16569,7 +16569,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n960px\n```",
+                            "default": "960px",
                             "description": "The breakpoint to define the maximum width boundary when using stack responsive layout."
                         },
                         {
@@ -16577,7 +16577,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to enable cell memoization.\n\nWhen the memoization is enabled, be sure to:\n     1- Update the value prop (i.e., row data) to trigger a re-render of the cells of a given row.\n     2- Where necessary, use the spread operator (...) when updating the value prop objs which creates new fresh\n     objects and avoids mutating the same objects.\n\nWhen the memoization is disabled, a re-render of the datatable will trigger a re-render of all cells, which can\nlead to performance issues with large datasets and is therefore not recommended."
                         },
                         {
@@ -16585,7 +16585,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string[]",
-                            "default": "```ts\n['rowData', 'field', 'allowCellSelection', 'isCellSelected', 'editMode', 'index', 'tabIndex',\n'editing', 'expanded', 'editingMeta', 'frozenCol', 'alignFrozenCol']\n```",
+                            "default": "['rowData', 'field', 'allowCellSelection', 'isCellSelected', 'editMode', 'index', 'tabIndex',\n'editing', 'expanded', 'editingMeta', 'frozenCol', 'alignFrozenCol']",
                             "description": "The cell props to be checked at memoization.\n\nPossible cell props are:\n    'hostName', 'allowCellSelection', 'cellMemo', 'cellMemoProps', 'cellMemoPropsDepth', 'cellClassName', 'checkIcon', 'collapsedRowIcon',\n    'field', 'resolveFieldData', 'column', 'cProps', 'dataKey', 'editMode', 'editing', 'editingMeta', 'onEditingMetaChange', 'editingKey',\n    'getEditingRowData', 'expanded', 'expandedRowIcon', 'frozenRow', 'frozenCol', 'alignFrozenCol', 'index', 'isSelectable', 'onCheckboxChange',\n    'onClick', 'onMouseDown', 'onMouseUp', 'onRadioChange', 'onRowEditCancel', 'onRowEditInit', 'onRowEditSave', 'onRowToggle', 'responsiveLayout',\n    'rowData', 'rowEditorCancelIcon', 'rowEditorInitIcon', 'rowEditorSaveIcon', 'rowIndex', 'rowSpan', 'selectOnEdit', 'isRowSelected', 'isCellSelected',\n    'selectionAriaLabel', 'showRowReorderElement', 'showSelectionElement', 'tabIndex', 'getTabIndex', 'tableProps', 'tableSelector', 'value',\n    'getVirtualScrollerOption', 'ptCallbacks', 'metaData', 'unstyled', 'findNextSelectableCell', 'findPrevSelectableCell', 'findDownSelectableCell',\n    'findUpSelectableCell', 'focusOnElement', 'focusOnInit', 'updateStickyPosition'\n\nIMPORTANT: Including a function to be checked will in general disable the memoization in practice, since functions are\ncompared by reference."
                         },
                         {
@@ -16593,7 +16593,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "The comparison depth when checking cell props (e.g., rowData) at memoization."
                         },
                         {
@@ -16601,7 +16601,7 @@
                             "optional": false,
                             "readonly": false,
                             "type": "true",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to cell selection is enabled or not."
                         },
                         {
@@ -16641,7 +16641,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"expand\" | \"fit\"",
-                            "default": "```ts\nfit\n```",
+                            "default": "fit",
                             "description": "Used to define the resize mode of the columns, valid values are \"fit\" and \"expand\"."
                         },
                         {
@@ -16649,7 +16649,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"equals\" | \"deepEquals\"",
-                            "default": "```ts\ndeepEquals\n```",
+                            "default": "deepEquals",
                             "description": "Algorithm to define if a row is selected, valid values are \"equals\" that compares by reference and \"deepEquals\" that compares all fields."
                         },
                         {
@@ -16665,7 +16665,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n,\n```",
+                            "default": ",",
                             "description": "Character to use as the csv separator."
                         },
                         {
@@ -16673,7 +16673,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Template of the current page report element. Available placeholders are {currentPage}, {totalPages}, {rows}, {first}, {last} and {totalRecords}"
                         },
                         {
@@ -16681,7 +16681,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string | ((data: any) => string)",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Name of the field that uniquely identifies a record in the data. Should be a unique business key to prevent re-rendering."
                         },
                         {
@@ -16689,7 +16689,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "0 | 1 | -1 | null",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Default sort order of an unsorted column."
                         },
                         {
@@ -16697,7 +16697,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a rectangle that can be dragged can be used to make a range selection."
                         },
                         {
@@ -16713,7 +16713,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Defines editing mode, options are \"cell\" and \"row\"."
                         },
                         {
@@ -16721,7 +16721,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((frozen: boolean) => ReactNode)",
-                            "default": "```ts\nNo results found\n```",
+                            "default": "No results found",
                             "description": "Text to display when there is no data."
                         },
                         {
@@ -16729,7 +16729,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Makes row groups toggleable, default is false."
                         },
                         {
@@ -16753,7 +16753,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\ndownload\n```",
+                            "default": "download",
                             "description": "Name of the exported file."
                         },
                         {
@@ -16769,7 +16769,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -16777,7 +16777,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"menu\" | \"row\"",
-                            "default": "```ts\nmenu\n```",
+                            "default": "menu",
                             "description": "Layout of the filter elements, valid values are \"row\" and \"menu\"."
                         },
                         {
@@ -16793,7 +16793,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -16809,7 +16809,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the first row to be displayed."
                         },
                         {
@@ -16833,7 +16833,7 @@
                             "optional": true,
                             "readonly": true,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the row is frozen or not. Read-Only necessary for unstyled TypeScript definition."
                         },
                         {
@@ -16873,7 +16873,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"custom\" | \"contains\" | \"in\" | \"equals\" | \"notEquals\" | \"notIn\" | \"lt\" | \"lte\" | \"gt\" | \"gte\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines filterMatchMode; \"startsWith\", \"contains\", \"endsWith\", \"equals\", \"notEquals\", \"in\", \"notIn\", \"lt\", \"lte\", \"gt\", \"gte\" and \"custom\"."
                         },
                         {
@@ -16913,7 +16913,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if data is loaded and interacted with in lazy manner."
                         },
                         {
@@ -16921,7 +16921,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a loader to indicate data load is in progress."
                         },
                         {
@@ -16937,7 +16937,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines whether metaKey is requred or not for the selection. When true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -16953,7 +16953,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Number of page links to display."
                         },
                         {
@@ -16961,7 +16961,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified as true, enables the pagination."
                         },
                         {
@@ -16977,7 +16977,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -16993,7 +16993,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"top\" | \"bottom\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of the paginator, options are \"top\",\"bottom\" or \"both\"."
                         },
                         {
@@ -17009,7 +17009,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "PaginatorTemplate",
-                            "default": "```ts\nFirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown\n```",
+                            "default": "FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown",
                             "description": "Template of the paginator. For details, refer to the template section of the paginator documentation for further options."
                         },
                         {
@@ -17033,7 +17033,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can have an un-sorted state."
                         },
                         {
@@ -17041,7 +17041,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can be reordered using drag and drop."
                         },
                         {
@@ -17049,7 +17049,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, rows can be reordered using drag and drop."
                         },
                         {
@@ -17073,7 +17073,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can be resized using drag and drop."
                         },
                         {
@@ -17081,7 +17081,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"scroll\" | \"stack\"",
-                            "default": "```ts\nscroll\n```",
+                            "default": "scroll",
                             "description": "Defines the responsive mode, valid options are \"stack\" and \"scroll\".",
                             "deprecated": "since version 9.2.0"
                         },
@@ -17162,7 +17162,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, enables horizontal and/or vertical scrolling."
                         },
                         {
@@ -17178,7 +17178,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, selects all rows on page."
                         },
                         {
@@ -17202,7 +17202,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When a selectable row is clicked on RadioButton and Checkbox selection, it automatically decides whether to focus on elements such as checkbox or radio."
                         },
                         {
@@ -17218,7 +17218,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled with paginator and checkbox selection mode, the select all checkbox in the header will select all rows on the current page."
                         },
                         {
@@ -17226,7 +17226,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Determines whether the cell editor will be opened when clicking to select any row on Selection and Cell Edit modes."
                         },
                         {
@@ -17234,7 +17234,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show grid lines between cells."
                         },
                         {
@@ -17242,7 +17242,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show headers."
                         },
                         {
@@ -17258,7 +17258,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"small\" | \"normal\" | \"large\"",
-                            "default": "```ts\nnormal\n```",
+                            "default": "normal",
                             "description": "Define to set alternative sizes. Valid values: \"small\", \"normal\" and \"large\"."
                         },
                         {
@@ -17282,7 +17282,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"multiple\" | \"single\"",
-                            "default": "```ts\nsingle\n```",
+                            "default": "single",
                             "description": "Defines whether sorting works on single column or on multiple columns."
                         },
                         {
@@ -17306,7 +17306,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"custom\" | \"session\" | \"local\"",
-                            "default": "```ts\nsession\n```",
+                            "default": "session",
                             "description": "Defines where a stateful table keeps its state, valid values are \"session\" for sessionStorage, \"local\" for localStorage and \"custom\"."
                         },
                         {
@@ -17314,7 +17314,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to displays rows with alternating colors."
                         },
                         {
@@ -17362,7 +17362,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -21161,7 +21161,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show it even there is only one page."
                         },
                         {
@@ -21177,7 +21177,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Template of the current page report element."
                         },
                         {
@@ -21193,7 +21193,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nNo records found.\n```",
+                            "default": "No records found.",
                             "description": "Text to display when there is no data."
                         },
                         {
@@ -21201,7 +21201,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the first record to render."
                         },
                         {
@@ -21217,7 +21217,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the grid structure in the container has gutter. Default value is false."
                         },
                         {
@@ -21233,7 +21233,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"grid\" | \"list\" | string & Record<string, unknown>",
-                            "default": "```ts\nlist\n```",
+                            "default": "list",
                             "description": "Layout of the items, valid values are \"list\" and \"grid\"."
                         },
                         {
@@ -21241,7 +21241,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if data is loaded and interacted with in lazy manner."
                         },
                         {
@@ -21265,7 +21265,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Number of page links to display."
                         },
                         {
@@ -21273,7 +21273,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified as true, enables the pagination."
                         },
                         {
@@ -21289,7 +21289,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -21305,7 +21305,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"top\" | \"bottom\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of the paginator, options are \"top\",\"bottom\" or \"both\"."
                         },
                         {
@@ -21321,7 +21321,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "PaginatorTemplate",
-                            "default": "```ts\nFirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown\n```",
+                            "default": "FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown",
                             "description": "Template of the paginator. For details, refer to the template section of the paginator documentation for further options."
                         },
                         {
@@ -21385,7 +21385,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -21968,7 +21968,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -21984,7 +21984,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -21992,7 +21992,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether background scroll should be blocked when dialog is visible."
                         },
                         {
@@ -22024,7 +22024,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the dialog can be closed by clicking the close icon, pressing escape key or clicking the modal background."
                         },
                         {
@@ -22040,7 +22040,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the dialog."
                         },
                         {
@@ -22072,7 +22072,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies if clicking the modal background should hide the dialog."
                         },
                         {
@@ -22080,7 +22080,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables dragging to change the position using header."
                         },
                         {
@@ -22088,7 +22088,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, first button receives focus on show."
                         },
                         {
@@ -22144,7 +22144,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Keeps dialog in the viewport."
                         },
                         {
@@ -22168,7 +22168,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the dialog can be displayed full screen."
                         },
                         {
@@ -22176,7 +22176,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the dialog is initially displayed full screen."
                         },
                         {
@@ -22200,7 +22200,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Minimum value for the left coordinate of dialog in dragging."
                         },
                         {
@@ -22208,7 +22208,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Minimum value for the top coordinate of dialog in dragging."
                         },
                         {
@@ -22216,7 +22216,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines if background should be blocked when dialog is displayed."
                         },
                         {
@@ -22224,7 +22224,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"center\" | \"left\" | \"top\" | \"bottom\" | \"right\" | \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\"",
-                            "default": "```ts\ncenter\n```",
+                            "default": "center",
                             "description": "Position of the dialog, options are \"center\", \"top\", \"bottom\", \"left\", \"right\", \"top-left\", \"top-right\", \"bottom-left\" or \"bottom-right\"."
                         },
                         {
@@ -22248,7 +22248,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables resizing of the content."
                         },
                         {
@@ -22256,7 +22256,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled dialog is displayed in RTL direction."
                         },
                         {
@@ -22264,7 +22264,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the close icon is displayed in the header."
                         },
                         {
@@ -22272,7 +22272,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the header or not."
                         },
                         {
@@ -22296,7 +22296,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -22304,7 +22304,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the dialog."
                         }
                     ]
@@ -22762,7 +22762,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Specifies the orientation, valid values are \"horizontal\" and \"vertical\"."
                         },
                         {
@@ -22786,7 +22786,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"dashed\" | \"dotted\" | \"solid\"",
-                            "default": "```ts\nsolid\n```",
+                            "default": "solid",
                             "description": "Border style type, default is \"solid\" and other options are \"dashed\" and \"dotted\"."
                         },
                         {
@@ -22794,7 +22794,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -22924,7 +22924,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of element. Valid values are 'bottom', 'top', 'left' and 'right'."
                         },
                         {
@@ -22956,7 +22956,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -23240,7 +23240,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and \"self\". The \"self\" value is used to render a component where it is located."
                         },
                         {
@@ -23264,7 +23264,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -23272,7 +23272,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to focus on the first visible or selected element."
                         },
                         {
@@ -23280,7 +23280,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the selected option will be shown with a check mark."
                         },
                         {
@@ -23328,7 +23328,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -23344,7 +23344,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, custom value instead of predefined options can be entered using the editable input field."
                         },
                         {
@@ -23352,7 +23352,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: DropdownProps) => ReactNode)",
-                            "default": "```ts\nNo results found\n```",
+                            "default": "No results found",
                             "description": "Template to display when filtering does not return any results."
                         },
                         {
@@ -23360,7 +23360,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: DropdownProps) => ReactNode)",
-                            "default": "```ts\nNo available options\n```",
+                            "default": "No available options",
                             "description": "Text to display when there are no options available."
                         },
                         {
@@ -23368,7 +23368,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, displays an input field to filter the items on keyup."
                         },
                         {
@@ -23376,7 +23376,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -23392,7 +23392,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -23408,7 +23408,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When the panel is opened, it specifies that the filter input should focus automatically."
                         },
                         {
@@ -23424,7 +23424,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"contains\" | \"equals\" | \"notEquals\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines how the items are filtered, valid values are \"contains\", (default) \"startsWith\", \"endsWith\", \"equals\" and \"notEquals\"."
                         },
                         {
@@ -23457,7 +23457,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the focus is placed on the hovered option."
                         },
                         {
@@ -23465,7 +23465,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the selected option will be add highlight class."
                         },
                         {
@@ -23497,7 +23497,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -23513,7 +23513,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a loader to indicate data load is in progress."
                         },
                         {
@@ -23553,7 +23553,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nitems\n```",
+                            "default": "items",
                             "description": "Property name or getter function that refers to the children options of option group."
                         },
                         {
@@ -23649,7 +23649,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field must be filled out before submitting the form."
                         },
                         {
@@ -23657,7 +23657,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Clears the filter value when hiding the dropdown."
                         },
                         {
@@ -23665,7 +23665,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n200px\n```",
+                            "default": "200px",
                             "description": "Height of the viewport in pixels, a scrollbar is defined if height of list exceeds this value."
                         },
                         {
@@ -23673,7 +23673,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the focused tab is activated."
                         },
                         {
@@ -23681,7 +23681,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a clear icon is displayed to clear the value."
                         },
                         {
@@ -23689,7 +23689,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a clear icon is displayed to clear the filtered value."
                         },
                         {
@@ -23697,7 +23697,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, overlay panel will be visible with input focus."
                         },
                         {
@@ -23745,7 +23745,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -23777,7 +23777,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         },
                         {
@@ -24361,7 +24361,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to instantiate the editor to read-only mode."
                         },
                         {
@@ -24369,7 +24369,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the header of editor."
                         },
                         {
@@ -24385,7 +24385,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -24638,7 +24638,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines the default visibility state of the content."
                         },
                         {
@@ -24686,7 +24686,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, content can toggled by clicking the legend."
                         },
                         {
@@ -24702,7 +24702,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -25009,7 +25009,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Pattern to restrict the allowed file types such as \"image/*\"."
                         },
                         {
@@ -25017,7 +25017,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, upload begins automatically after selection is completed."
                         },
                         {
@@ -25089,7 +25089,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to use the default upload or a manual implementation defined in uploadHandler callback."
                         },
                         {
@@ -25097,7 +25097,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Disables the upload functionality."
                         },
                         {
@@ -25145,7 +25145,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n\"Maximum upload size is.\"\n```",
+                            "default": "\"Maximum upload size is.\"",
                             "description": "Detail message of the invalid fize size."
                         },
                         {
@@ -25153,7 +25153,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nInvalid file size\n```",
+                            "default": "Invalid file size",
                             "description": "Summary message of the invalid fize size."
                         },
                         {
@@ -25177,7 +25177,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"basic\" | \"advanced\"",
-                            "default": "```ts\nadvanced\n```",
+                            "default": "advanced",
                             "description": "Defines the UI of the component, possible values are \"advanced\" and \"basic\"."
                         },
                         {
@@ -25185,7 +25185,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Used to select multiple files at once from file dialog."
                         },
                         {
@@ -25201,7 +25201,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n50\n```",
+                            "default": "50",
                             "description": "Width of the image thumbnail in pixels."
                         },
                         {
@@ -25257,7 +25257,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -25289,7 +25289,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates."
                         }
                     ]
@@ -26144,7 +26144,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -26265,7 +26265,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the first item."
                         },
                         {
@@ -26273,7 +26273,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Items are displayed with a slideshow in autoPlay mode."
                         },
                         {
@@ -26281,7 +26281,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -26289,7 +26289,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, item is changed on indicator item's hover."
                         },
                         {
@@ -26305,7 +26305,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if scrolling would be infinite."
                         },
                         {
@@ -26329,7 +26329,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display the component on fullscreen."
                         },
                         {
@@ -26345,7 +26345,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of indicators. Valid values are \"bottom\", \"top\", \"left\" and \"right\"."
                         },
                         {
@@ -26377,7 +26377,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n3\n```",
+                            "default": "3",
                             "description": "Number of items per page."
                         },
                         {
@@ -26417,7 +26417,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display indicator container."
                         },
                         {
@@ -26425,7 +26425,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, indicator container is displayed on item container."
                         },
                         {
@@ -26433,7 +26433,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display navigation buttons in item container."
                         },
                         {
@@ -26441,7 +26441,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display navigation buttons on item container's hover."
                         },
                         {
@@ -26449,7 +26449,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display navigation buttons in thumbnail container."
                         },
                         {
@@ -26457,7 +26457,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display thumbnail container."
                         },
                         {
@@ -26465,7 +26465,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of thumbnails. Valid values are \"bottom\", \"top\", \"left\" and \"right\"."
                         },
                         {
@@ -26473,7 +26473,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n4000\n```",
+                            "default": "4000",
                             "description": "Time in milliseconds to scroll items."
                         },
                         {
@@ -26489,7 +26489,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -27678,7 +27678,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"right\"",
-                            "default": "```ts\nright\n```",
+                            "default": "right",
                             "description": "Position of the icon"
                         },
                         {
@@ -27702,7 +27702,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -29774,7 +29774,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the preview."
                         },
                         {
@@ -29911,7 +29911,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -30231,7 +30231,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the content is displayed or not. To use in controlled mode you must implement  `onToggle`  callback at a minimum."
                         },
                         {
@@ -30255,7 +30255,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a button to switch back to display mode."
                         },
                         {
@@ -30271,7 +30271,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -30295,7 +30295,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -30549,7 +30549,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -30638,7 +30638,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Clears the incomplete value on blur."
                         },
                         {
@@ -30654,7 +30654,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element value cannot be altered."
                         },
                         {
@@ -30662,7 +30662,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -30709,7 +30709,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field is read-only."
                         },
                         {
@@ -30717,7 +30717,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element must be filled out before submitting the form."
                         },
                         {
@@ -30733,7 +30733,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n_\n```",
+                            "default": "_",
                             "description": "Placeholder character in mask."
                         },
                         {
@@ -30757,7 +30757,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if model sets the raw unmasked value to bound value or the formatted mask value."
                         },
                         {
@@ -30765,7 +30765,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -30773,7 +30773,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, instead of blocking keys, input is validated internally to test against the regular expression."
                         },
                         {
@@ -30789,7 +30789,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -30951,7 +30951,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Determines whether the input field is empty."
                         },
                         {
@@ -30967,7 +30967,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -30975,7 +30975,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\" | \"stacked\"",
-                            "default": "```ts\nstacked\n```",
+                            "default": "stacked",
                             "description": "Layout of the buttons."
                         },
                         {
@@ -30999,7 +30999,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nsymbol\n```",
+                            "default": "symbol",
                             "description": "How to display the currency in currency formatting. Possible values are \"symbol\" to use a localized currency symbol such as €, ü\"code\" to use the ISO currency code, \"name\" to use a localized currency name such as \"dollar\"; the default is \"symbol\"."
                         },
                         {
@@ -31031,7 +31031,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to format the value."
                         },
                         {
@@ -31087,7 +31087,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -31103,7 +31103,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nbest fit\n```",
+                            "default": "best fit",
                             "description": "The locale matching algorithm to use. See [Locale Negotation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation) for details."
                         },
                         {
@@ -31151,7 +31151,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"decimal\" | \"currency\"",
-                            "default": "```ts\ndecimal\n```",
+                            "default": "decimal",
                             "description": "Defines the behavior of the component."
                         },
                         {
@@ -31215,7 +31215,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element must be filled out before submitting the form."
                         },
                         {
@@ -31223,7 +31223,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "RoundingMode",
-                            "default": "```ts\nhalfExpand\n```",
+                            "default": "halfExpand",
                             "description": "How decimals should be rounded. [further information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode)."
                         },
                         {
@@ -31231,7 +31231,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays spinner buttons."
                         },
                         {
@@ -31247,7 +31247,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Step factor to increment/decrement the value."
                         },
                         {
@@ -31287,7 +31287,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\ntext\n```",
+                            "default": "text",
                             "description": "Type of the input element."
                         },
                         {
@@ -31295,7 +31295,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -31303,7 +31303,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to use grouping separators, such as thousands separators or thousand/lakh/crore separators."
                         },
                         {
@@ -31319,7 +31319,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -31574,7 +31574,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -31590,7 +31590,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field is integer-only."
                         },
                         {
@@ -31598,7 +31598,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -31606,7 +31606,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n4\n```",
+                            "default": "4",
                             "description": "Number of characters to initiate."
                         },
                         {
@@ -31614,7 +31614,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Mask pattern."
                         },
                         {
@@ -31638,7 +31638,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field is read-only."
                         },
                         {
@@ -31654,7 +31654,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -31662,7 +31662,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string | number | null",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Specifies the value of the component."
                         },
                         {
@@ -31670,7 +31670,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -31870,7 +31870,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -31878,7 +31878,7 @@
                             "optional": false,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies whether a inputswitch should be checked or not."
                         },
                         {
@@ -31902,7 +31902,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -31910,7 +31910,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "any",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Value in unchecked state."
                         },
                         {
@@ -31942,7 +31942,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -32006,7 +32006,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "any",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Value in checked state."
                         },
                         {
@@ -32014,7 +32014,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -32194,7 +32194,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -32250,7 +32250,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -32258,7 +32258,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, instead of blocking keys, input is validated internally to test against the regular expression."
                         },
                         {
@@ -32274,7 +32274,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -32410,7 +32410,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, height of textarea changes as being typed."
                         },
                         {
@@ -32426,7 +32426,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -32474,7 +32474,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -32490,7 +32490,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -32628,7 +32628,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -32644,7 +32644,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n100\n```",
+                            "default": "100",
                             "description": "Maximum boundary value."
                         },
                         {
@@ -32652,7 +32652,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Mininum boundary value."
                         },
                         {
@@ -32684,7 +32684,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nvar(--surface-border, LightGray)\n```",
+                            "default": "var(--surface-border, LightGray)",
                             "description": "Background color of the range."
                         },
                         {
@@ -32692,7 +32692,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component value cannot be edited."
                         },
                         {
@@ -32700,7 +32700,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the show the value inside the knob."
                         },
                         {
@@ -32708,7 +32708,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n100\n```",
+                            "default": "100",
                             "description": "Size of the component in pixels."
                         },
                         {
@@ -32716,7 +32716,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Step factor to increment/decrement the value."
                         },
                         {
@@ -32724,7 +32724,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n14\n```",
+                            "default": "14",
                             "description": "Width of the knob stroke."
                         },
                         {
@@ -32740,7 +32740,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nvar(--text-color-secondary, Black)\n```",
+                            "default": "var(--text-color-secondary, Black)",
                             "description": "Color of the value text."
                         },
                         {
@@ -32748,7 +32748,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -32764,7 +32764,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nvar(--primary-color, Black)\n```",
+                            "default": "var(--primary-color, Black)",
                             "description": "Background of the value."
                         },
                         {
@@ -32772,7 +32772,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n{value}\n```",
+                            "default": "{value}",
                             "description": "Template string of the value."
                         }
                     ]
@@ -32935,7 +32935,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to focus on the first visible or selected element."
                         },
                         {
@@ -32951,7 +32951,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "A property to uniquely match the value in options for better performance."
                         },
                         {
@@ -32959,7 +32959,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, disables the component."
                         },
                         {
@@ -32983,7 +32983,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, displays a filter input at header."
                         },
                         {
@@ -32991,7 +32991,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -32999,7 +32999,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "any",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Props for the filter input, any prop is passed implicity to the filter input element."
                         },
                         {
@@ -33007,7 +33007,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -33015,7 +33015,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"contains\" | \"equals\" | \"notEquals\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines how the items are filtered, valid values are \"contains\", (default) \"startsWith\", \"endsWith\", \"equals\" and \"notEquals\"."
                         },
                         {
@@ -33047,7 +33047,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the focus is placed on the hovered option."
                         },
                         {
@@ -33055,7 +33055,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -33087,7 +33087,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines how multiple items can be selected, when true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -33095,7 +33095,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, allows selecting multiple values."
                         },
                         {
@@ -33175,7 +33175,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the focused option is selected."
                         },
                         {
@@ -33199,7 +33199,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -33681,7 +33681,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Defines the orientation, valid values are horizontal and vertical."
                         },
                         {
@@ -33705,7 +33705,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n400px\n```",
+                            "default": "400px",
                             "description": "Maximum height of the options panel on responsive mode."
                         },
                         {
@@ -33737,7 +33737,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -34085,7 +34085,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, highlights the first item in the list by default."
                         },
                         {
@@ -34109,7 +34109,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay between keystrokes to wait before sending a query."
                         },
                         {
@@ -34213,7 +34213,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n200px\n```",
+                            "default": "200px",
                             "description": "Maximum height of the suggestions panel."
                         },
                         {
@@ -34237,7 +34237,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string | string[]",
-                            "default": "```ts\n\"@\"\n```",
+                            "default": "\"@\"",
                             "description": "Set trigger keyword."
                         },
                         {
@@ -34245,7 +34245,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -34253,7 +34253,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -34642,7 +34642,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -34650,7 +34650,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -34658,7 +34658,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -34674,7 +34674,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the Menu Popup."
                         },
                         {
@@ -34690,7 +34690,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if menu would displayed as a popup."
                         },
                         {
@@ -34698,7 +34698,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"right\"",
-                            "default": "```ts\nleft\n```",
+                            "default": "left",
                             "description": "In popup mode determines how the overlay is aligned with its target. Values either 'left' or 'right'."
                         },
                         {
@@ -34738,7 +34738,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -35100,7 +35100,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -35405,7 +35405,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Visibility of submenu."
                         },
                         {
@@ -35413,7 +35413,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When set as true, disables the menuitem."
                         },
                         {
@@ -35421,7 +35421,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When set as false, hides the menuitem."
                         },
                         {
@@ -35437,7 +35437,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines the item as a separator."
                         },
                         {
@@ -35621,7 +35621,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "IconType<MessageProps>",
-                            "default": "```ts\nbased on severity\n```",
+                            "default": "based on severity",
                             "description": "Icon for the message. If not set it will default to severity icon."
                         },
                         {
@@ -35661,7 +35661,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -35832,7 +35832,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -36140,7 +36140,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\n'horizontal'\n```",
+                            "default": "'horizontal'",
                             "description": "The orientation of the label. Can be either 'horizontal' or 'vertical'."
                         },
                         {
@@ -36148,7 +36148,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"end\" | \"start\"",
-                            "default": "```ts\n'end'\n```",
+                            "default": "'end'",
                             "description": "The position of the label. Can be either 'start' or 'end'."
                         },
                         {
@@ -36156,7 +36156,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n100\n```",
+                            "default": "100",
                             "description": "The maximum value for the MeterGroup."
                         },
                         {
@@ -36172,7 +36172,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "The minimum value for the MeterGroup."
                         },
                         {
@@ -36180,7 +36180,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\n'horizontal'\n```",
+                            "default": "'horizontal'",
                             "description": "The orientation of the MeterGroup. Can be either 'horizontal' or 'vertical'."
                         },
                         {
@@ -36437,7 +36437,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -36453,7 +36453,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to focus on the first visible or selected element."
                         },
                         {
@@ -36509,7 +36509,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -36517,7 +36517,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"comma\" | \"chip\"",
-                            "default": "```ts\ncomma\n```",
+                            "default": "comma",
                             "description": "Used mode to display the selected item. Valid values are 'comma' and 'chip'."
                         },
                         {
@@ -36533,7 +36533,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: MultiSelectProps) => ReactNode)",
-                            "default": "```ts\nNo records found\n```",
+                            "default": "No records found",
                             "description": "Template to display when filtering does not return any results."
                         },
                         {
@@ -36549,7 +36549,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When specified, displays an input field to filter the items on keyup."
                         },
                         {
@@ -36557,7 +36557,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -36565,7 +36565,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -36581,7 +36581,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When the panel is opened, it specifies that the filter input should focus automatically."
                         },
                         {
@@ -36589,7 +36589,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -36597,7 +36597,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"contains\" | \"equals\" | \"notEquals\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines how the items are filtered, valid values are \"contains\", (default) \"startsWith\", \"endsWith\", \"equals\" and \"notEquals\"."
                         },
                         {
@@ -36621,7 +36621,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display selected items in the label section or always display the placeholder as the default label."
                         },
                         {
@@ -36629,7 +36629,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Use flex layout for the items panel."
                         },
                         {
@@ -36637,7 +36637,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the focus is placed on the hovered option."
                         },
                         {
@@ -36653,7 +36653,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Render the items panel inline."
                         },
                         {
@@ -36677,7 +36677,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -36709,7 +36709,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a loader to indicate data load is in progress."
                         },
                         {
@@ -36797,7 +36797,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the overlay panel."
                         },
                         {
@@ -36869,7 +36869,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Clears the filter value when hiding the dropdown."
                         },
                         {
@@ -36877,7 +36877,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n200px\n```",
+                            "default": "200px",
                             "description": "Height of the viewport in pixels, a scrollbar is defined if height of list exceeds this value."
                         },
                         {
@@ -36885,7 +36885,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether all data is selected."
                         },
                         {
@@ -36901,7 +36901,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n{0} items selected\n```",
+                            "default": "{0} items selected",
                             "description": "Label to display after exceeding max selected labels."
                         },
                         {
@@ -36925,7 +36925,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, the focused tab is activated."
                         },
                         {
@@ -36933,7 +36933,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a clear icon is displayed to clear the value."
                         },
                         {
@@ -36941,7 +36941,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the select all checkbox inside the panel's header."
                         },
                         {
@@ -36989,7 +36989,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -37013,7 +37013,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         },
                         {
@@ -37780,7 +37780,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -37804,7 +37804,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element value cannot be altered."
                         },
                         {
@@ -37812,7 +37812,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "If false, the empty state is skipped in the chekbox."
                         },
                         {
@@ -37828,7 +37828,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component has invalid state style."
                         },
                         {
@@ -37884,7 +37884,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the value cannot be changed."
                         },
                         {
@@ -37908,7 +37908,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -37924,7 +37924,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -38215,7 +38215,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to focus on the first visible or selected element."
                         },
                         {
@@ -38223,7 +38223,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n'960px'.\n```",
+                            "default": "'960px'.",
                             "description": "The breakpoint to define the maximum width boundary when responsiveness is enabled."
                         },
                         {
@@ -38247,7 +38247,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to enable dragdrop based reordering."
                         },
                         {
@@ -38255,7 +38255,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -38263,7 +38263,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -38279,7 +38279,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -38287,7 +38287,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"contains\" | \"equals\" | \"notEquals\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines how the items are filtered, valid values are \"contains\", (default) \"startsWith\", \"endsWith\", \"equals\" and \"notEquals\"."
                         },
                         {
@@ -38311,7 +38311,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the focus is placed on the hovered option."
                         },
                         {
@@ -38383,7 +38383,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -38780,7 +38780,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -39214,7 +39214,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -39222,7 +39222,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nclose\n```",
+                            "default": "close",
                             "description": "Aria label of the close icon."
                         },
                         {
@@ -39254,7 +39254,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the preview."
                         },
                         {
@@ -39262,7 +39262,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Enables to hide the overlay when outside is clicked."
                         },
                         {
@@ -39286,7 +39286,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, displays a close icon at top right corner."
                         },
                         {
@@ -39302,7 +39302,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -39572,7 +39572,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Template of the current page report element. Available placeholders are {currentPage}, {totalPages}, {rows}, {first}, {last} and {totalRecords}"
                         },
                         {
@@ -39580,7 +39580,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -39588,7 +39588,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Zero-relative number of the first row to be displayed."
                         },
                         {
@@ -39628,7 +39628,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Number of page links to display."
                         },
                         {
@@ -39668,7 +39668,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Data count to display per page."
                         },
                         {
@@ -39684,7 +39684,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string | PaginatorTemplateOptions",
-                            "default": "```ts\nFirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown\n```",
+                            "default": "FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown",
                             "description": "Custom template of the paginator."
                         },
                         {
@@ -39692,7 +39692,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Number of total records."
                         },
                         {
@@ -39700,7 +39700,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -40842,7 +40842,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines the initial state of panel content, supports one or two-way binding as well."
                         },
                         {
@@ -40922,7 +40922,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if content of panel can be expanded and collapsed."
                         },
                         {
@@ -40938,7 +40938,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -41345,7 +41345,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether multiple tabs can be activated at the same time or not."
                         },
                         {
@@ -41377,7 +41377,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -41803,7 +41803,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -41827,7 +41827,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the strength indicator or not."
                         },
                         {
@@ -41899,7 +41899,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -41915,7 +41915,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nMedium\n```",
+                            "default": "Medium",
                             "description": "Text for a medium password."
                         },
                         {
@@ -41923,7 +41923,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,}).\n```",
+                            "default": "^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,}).",
                             "description": "Regex for a medium level password."
                         },
                         {
@@ -41947,7 +41947,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nPlease enter a password\n```",
+                            "default": "Please enter a password",
                             "description": "Text to prompt password entry."
                         },
                         {
@@ -41979,7 +41979,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nStrong\n```",
+                            "default": "Strong",
                             "description": "Text for a strong password."
                         },
                         {
@@ -41987,7 +41987,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})\n```",
+                            "default": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})",
                             "description": "Regex for a strong level password."
                         },
                         {
@@ -41995,7 +41995,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show an icon to display the password as plain text."
                         },
                         {
@@ -42027,7 +42027,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -42035,7 +42035,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         },
                         {
@@ -42043,7 +42043,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nWeak\n```",
+                            "default": "Weak",
                             "description": "Text for a weak password."
                         }
                     ]
@@ -42324,7 +42324,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to focus on the first visible or selected element."
                         },
                         {
@@ -42332,7 +42332,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n'960px'.\n```",
+                            "default": "'960px'.",
                             "description": "The breakpoint to define the maximum width boundary when responsiveness is enabled."
                         },
                         {
@@ -42364,7 +42364,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, displays an input field to filter the items on keyup."
                         },
                         {
@@ -42380,7 +42380,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -42388,7 +42388,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"contains\" | \"equals\" | \"notEquals\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines how the items are filtered, valid values are \"contains\", (default) \"startsWith\", \"endsWith\", \"equals\" and \"notEquals\"."
                         },
                         {
@@ -42396,7 +42396,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When enabled, the focus is placed on the hovered option."
                         },
                         {
@@ -42420,7 +42420,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines how multiple items can be selected, when true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -42508,7 +42508,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show buttons of source list."
                         },
                         {
@@ -42516,7 +42516,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show filter input for source list when filterBy is enabled."
                         },
                         {
@@ -42524,7 +42524,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show buttons of target list."
                         },
                         {
@@ -42532,7 +42532,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show filter input for target list when filterBy is enabled."
                         },
                         {
@@ -42700,7 +42700,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -43271,7 +43271,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"determinate\" | \"indeterminate\"",
-                            "default": "```ts\ndeterminate\n```",
+                            "default": "determinate",
                             "description": "Defines the mode of the progress, valid values are \"determinate\" and \"indeterminate\"."
                         },
                         {
@@ -43295,7 +43295,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Show or hide progress bar value."
                         },
                         {
@@ -43303,7 +43303,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n%\n```",
+                            "default": "%",
                             "description": "Unit sign appended to the value."
                         },
                         {
@@ -43311,7 +43311,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -43436,7 +43436,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n2s\n```",
+                            "default": "2s",
                             "description": "Duration of the rotate animation."
                         },
                         {
@@ -43476,7 +43476,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n2\n```",
+                            "default": "2",
                             "description": "Width of the circle stroke."
                         },
                         {
@@ -43484,7 +43484,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -43605,7 +43605,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -43613,7 +43613,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies whether a checkbox should be checked or not."
                         },
                         {
@@ -43629,7 +43629,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -43653,7 +43653,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -43693,7 +43693,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that an input field must be filled out before submitting the form."
                         },
                         {
@@ -43717,7 +43717,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -43733,7 +43733,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -43893,7 +43893,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When specified a cancel icon is displayed to allow removing the value."
                         },
                         {
@@ -43925,7 +43925,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -43981,7 +43981,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the input cannot be typed."
                         },
                         {
@@ -43989,7 +43989,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Number of stars."
                         },
                         {
@@ -44013,7 +44013,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -44232,7 +44232,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -44341,7 +44341,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -44472,7 +44472,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -44583,7 +44583,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"auto\" | \"smooth\"",
-                            "default": "```ts\nsmooth\n```",
+                            "default": "smooth",
                             "description": "Defines the scrolling behavior, \"smooth\" adds an animation and \"auto\" scrolls with a jump."
                         },
                         {
@@ -44639,7 +44639,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"window\" | \"parent\"",
-                            "default": "```ts\nwindow\n```",
+                            "default": "window",
                             "description": "Target of the ScrollTop, valid values are \"window\" and \"parent\"."
                         },
                         {
@@ -44647,7 +44647,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n400\n```",
+                            "default": "400",
                             "description": "Defines the threshold value of the vertical scroll position of the target to toggle the visibility."
                         },
                         {
@@ -44663,7 +44663,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -44802,7 +44802,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether selection can not be cleared."
                         },
                         {
@@ -44834,7 +44834,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -44842,7 +44842,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -44850,7 +44850,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, allows selecting multiple values."
                         },
                         {
@@ -44930,7 +44930,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether selection can be cleared.",
                             "deprecated": "Use 'allowEmpty' property instead."
                         },
@@ -44939,7 +44939,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -45171,7 +45171,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and self. The self value is used to render a component where it is located."
                         },
                         {
@@ -45179,7 +45179,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nclose\n```",
+                            "default": "close",
                             "description": "Aria label of the close icon."
                         },
                         {
@@ -45187,7 +45187,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -45195,7 +45195,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to block scrolling of the document when sidebar is active."
                         },
                         {
@@ -45219,7 +45219,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the sidebar."
                         },
                         {
@@ -45235,7 +45235,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to dismiss sidebar on click of the mask."
                         },
                         {
@@ -45243,7 +45243,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Adds a close icon to the header to hide the dialog."
                         },
                         {
@@ -45251,7 +45251,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: SidebarProps) => ReactNode)",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Custom template for the header."
                         },
                         {
@@ -45259,7 +45259,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: SidebarProps) => ReactNode)",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Custom icons template for the header."
                         },
                         {
@@ -45283,7 +45283,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to a modal layer behind the sidebar."
                         },
                         {
@@ -45291,7 +45291,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nleft\n```",
+                            "default": "left",
                             "description": "Specifies the position of the sidebar, valid values are \"left\" and \"right\"."
                         },
                         {
@@ -45315,7 +45315,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to display a close icon inside the panel."
                         },
                         {
@@ -45331,7 +45331,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -45339,7 +45339,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the dialog."
                         }
                     ]
@@ -45542,7 +45542,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"none\" | \"wave\"",
-                            "default": "```ts\nwave\n```",
+                            "default": "wave",
                             "description": "Type of the animation, valid options are \"wave\" and \"none\"."
                         },
                         {
@@ -45566,7 +45566,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n1rem\n```",
+                            "default": "1rem",
                             "description": "Height of the element."
                         },
                         {
@@ -45590,7 +45590,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"circle\" | \"rectangle\"",
-                            "default": "```ts\nrectangle\n```",
+                            "default": "rectangle",
                             "description": "It specifies an alternate text for an image, if the image cannot be displayed."
                         },
                         {
@@ -45606,7 +45606,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -45614,7 +45614,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n100%\n```",
+                            "default": "100%",
                             "description": "Width of the element."
                         }
                     ]
@@ -45757,7 +45757,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -45765,7 +45765,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -45781,7 +45781,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nBack\n```",
+                            "default": "Back",
                             "description": "Label of element to navigate back."
                         },
                         {
@@ -45789,7 +45789,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -45805,7 +45805,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Specifies if pressing escape key should hide the SlideMenu Popup."
                         },
                         {
@@ -45813,7 +45813,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nease-out\n```",
+                            "default": "ease-out",
                             "description": "Easing animation to use for sliding."
                         },
                         {
@@ -45821,7 +45821,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n250\n```",
+                            "default": "250",
                             "description": "Duration of the sliding animation in milliseconds."
                         },
                         {
@@ -45829,7 +45829,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n190\n```",
+                            "default": "190",
                             "description": "Width of the submenus."
                         },
                         {
@@ -45845,7 +45845,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if menu would displayed as a popup."
                         },
                         {
@@ -45885,7 +45885,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -45893,7 +45893,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n175\n```",
+                            "default": "175",
                             "description": "Height of the scrollable area, a scrollbar appears if a menu height is longer than this value."
                         }
                     ]
@@ -46191,7 +46191,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -46199,7 +46199,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n100\n```",
+                            "default": "100",
                             "description": "Maximum boundary value."
                         },
                         {
@@ -46207,7 +46207,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Mininum boundary value."
                         },
                         {
@@ -46215,7 +46215,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Orientation of the slider, valid values are horizontal and vertical."
                         },
                         {
@@ -46239,7 +46239,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When speficed, allows two boundary values to be picked."
                         },
                         {
@@ -46247,7 +46247,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Step factor to increment/decrement the value."
                         },
                         {
@@ -46255,7 +46255,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -46263,7 +46263,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number | [number, number]",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Value of the component."
                         }
                     ]
@@ -46477,7 +46477,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"right\" | \"up\" | \"down\" | \"up-left\" | \"up-right\" | \"down-left\" | \"down-right\"",
-                            "default": "```ts\nup\n```",
+                            "default": "up",
                             "description": "Specifies the opening direction of actions. Valid values are 'up', 'down', 'left', 'right', 'up-left', 'up-right', 'down-left' and 'down-right'"
                         },
                         {
@@ -46485,7 +46485,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the component is disabled."
                         },
                         {
@@ -46501,7 +46501,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the actions close when clicked outside."
                         },
                         {
@@ -46509,7 +46509,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show a mask element behind the speeddial."
                         },
                         {
@@ -46557,7 +46557,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Radius for *circle types."
                         },
                         {
@@ -46565,7 +46565,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defined to rotate showIcon when hideIcon is not present."
                         },
                         {
@@ -46581,7 +46581,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n30\n```",
+                            "default": "30",
                             "description": "Transition delay step for each action item."
                         },
                         {
@@ -46589,7 +46589,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"linear\" | \"circle\" | \"semi-circle\" | \"quarter-circle\"",
-                            "default": "```ts\nlinear\n```",
+                            "default": "linear",
                             "description": "Specifies the opening type of actions."
                         },
                         {
@@ -46597,7 +46597,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -46605,7 +46605,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the visibility of the overlay."
                         }
                     ]
@@ -46857,7 +46857,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -46897,7 +46897,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -46929,7 +46929,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Display loading icon of the button"
                         },
                         {
@@ -46985,7 +46985,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a border class without a background initially."
                         },
                         {
@@ -47009,7 +47009,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a shadow to indicate elevation."
                         },
                         {
@@ -47017,7 +47017,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a circular border radius to the button."
                         },
                         {
@@ -47041,7 +47041,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Add a textual class to the button without a background initially."
                         },
                         {
@@ -47073,7 +47073,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -47081,7 +47081,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When present, it specifies that the element should be visible."
                         }
                     ]
@@ -47402,7 +47402,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n4\n```",
+                            "default": "4",
                             "description": "Size of the divider in pixels."
                         },
                         {
@@ -47410,7 +47410,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Orientation of the panels, valid values are \"horizontal\" and \"vertical\"."
                         },
                         {
@@ -47442,7 +47442,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"session\" | \"local\"",
-                            "default": "```ts\nsession\n```",
+                            "default": "session",
                             "description": "Defines where a stateful splitter keeps its state, valid values are \"session\" for sessionStorage and \"local\" for localStorage."
                         },
                         {
@@ -47450,7 +47450,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Step factor to increment/decrement the size of the panels while pressing the arrow keys."
                         },
                         {
@@ -47458,7 +47458,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -47699,7 +47699,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Active step index of stepper."
                         },
                         {
@@ -47731,7 +47731,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the steps are clickable or not."
                         },
                         {
@@ -47739,7 +47739,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nhorizontal\n```",
+                            "default": "horizontal",
                             "description": "Orientation of the stepper."
                         },
                         {
@@ -47771,7 +47771,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -48194,7 +48194,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the active item."
                         },
                         {
@@ -48234,7 +48234,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the items are clickable or not."
                         },
                         {
@@ -48242,7 +48242,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -48531,7 +48531,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to trigger leave animation when outside of the element is clicked."
                         },
                         {
@@ -48624,7 +48624,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Active index of menuitem."
                         },
                         {
@@ -48664,7 +48664,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -48891,7 +48891,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if tab can be removed."
                         },
                         {
@@ -48923,7 +48923,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the tab is disabled."
                         },
                         {
@@ -49019,7 +49019,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -49027,7 +49027,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When set as false, hides the tab panel."
                         }
                     ]
@@ -49064,7 +49064,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Active index of the TabView."
                         },
                         {
@@ -49112,7 +49112,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to render the contents of the selected tab or all tabs."
                         },
                         {
@@ -49120,7 +49120,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled displays buttons at each side of the tab headers to scroll the tab list."
                         },
                         {
@@ -49128,7 +49128,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -49682,7 +49682,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the corners of the tag are rounded."
                         },
                         {
@@ -49690,7 +49690,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"info\" | \"warning\" | \"success\" | \"secondary\" | \"danger\" | \"contrast\" | null",
-                            "default": "```ts\nnull\n```",
+                            "default": "null",
                             "description": "Severity type of the tag."
                         },
                         {
@@ -49698,7 +49698,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -49841,7 +49841,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -50116,7 +50116,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -50124,7 +50124,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -50132,7 +50132,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -50164,7 +50164,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if menu would displayed as a popup."
                         },
                         {
@@ -50188,7 +50188,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n400px\n```",
+                            "default": "400px",
                             "description": "Maximum height of the options panel on responsive mode."
                         },
                         {
@@ -50212,7 +50212,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -50461,7 +50461,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"alternate\" | \"left\" | \"top\" | \"bottom\" | \"right\"",
-                            "default": "```ts\nleft\n```",
+                            "default": "left",
                             "description": "Position of the timeline bar relative to the content. Valid values are \"left\", \"right for vertical layout and \"top\", \"bottom\" for horizontal layout."
                         },
                         {
@@ -50493,7 +50493,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"horizontal\" | \"vertical\"",
-                            "default": "```ts\nvertical\n```",
+                            "default": "vertical",
                             "description": "Orientation of the timeline, valid values are \"vertical\" and \"horizontal\"."
                         },
                         {
@@ -50533,7 +50533,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -50708,7 +50708,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\nself\n```",
+                            "default": "self",
                             "description": "DOM element instance where the component should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -50716,7 +50716,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to add to initial layering of MantleUI components which start from 1000."
                         },
                         {
@@ -50740,7 +50740,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"center\" | \"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\" | \"top-center\" | \"bottom-center\"",
-                            "default": "```ts\ntop-right\n```",
+                            "default": "top-right",
                             "description": "Position of the toast in viewport, valid values are 'center', 'top-center', 'top-left', 'top-right', 'bottom-center', 'bottom-left', 'bottom-right'."
                         },
                         {
@@ -51216,7 +51216,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies the on/off state of the button."
                         },
                         {
@@ -51232,7 +51232,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element should be disabled."
                         },
                         {
@@ -51240,7 +51240,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"right\"",
-                            "default": "```ts\nleft\n```",
+                            "default": "left",
                             "description": "Position of the icon, valid values are \"left\" and \"right\"."
                         },
                         {
@@ -51248,7 +51248,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -51264,7 +51264,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nno\n```",
+                            "default": "no",
                             "description": "Label for the off state."
                         },
                         {
@@ -51280,7 +51280,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nyes\n```",
+                            "default": "yes",
                             "description": "Label for the on state."
                         },
                         {
@@ -51328,7 +51328,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -51612,7 +51612,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -51782,7 +51782,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -51798,7 +51798,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to hide tooltip when hovering over tooltip content."
                         },
                         {
@@ -51806,7 +51806,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -51814,7 +51814,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -51838,7 +51838,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies if pressing escape key should hide the tooltip."
                         },
                         {
@@ -51854,7 +51854,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the tooltip should be hidden."
                         },
                         {
@@ -51862,7 +51862,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"focus\" | \"hover\"",
-                            "default": "```ts\nhover\n```",
+                            "default": "hover",
                             "description": "Event to show the tooltip."
                         },
                         {
@@ -51870,7 +51870,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to hide the tooltip in milliseconds."
                         },
                         {
@@ -51878,7 +51878,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseleave\n```",
+                            "default": "mouseleave",
                             "description": "Event to hide the tooltip if the event property is empty."
                         },
                         {
@@ -51894,7 +51894,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the tooltip will follow the mouse."
                         },
                         {
@@ -51902,7 +51902,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines left position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -51910,7 +51910,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines top position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -51926,7 +51926,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\" | \"mouse\"",
-                            "default": "```ts\nright\n```",
+                            "default": "right",
                             "description": "Position of the tooltip."
                         },
                         {
@@ -51950,7 +51950,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to show the tooltip in milliseconds."
                         },
                         {
@@ -51958,7 +51958,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseenter\n```",
+                            "default": "mouseenter",
                             "description": "Event to show the tooltip if the event property is empty."
                         },
                         {
@@ -51966,7 +51966,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show tooltip for disabled elements."
                         },
                         {
@@ -51990,7 +51990,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -51998,7 +51998,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to update the tooltip in milliseconds."
                         }
                     ]
@@ -52212,7 +52212,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -52228,7 +52228,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to hide tooltip when hovering over tooltip content."
                         },
                         {
@@ -52236,7 +52236,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to automatically manage layering."
                         },
                         {
@@ -52244,7 +52244,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Base zIndex value to use in layering."
                         },
                         {
@@ -52260,7 +52260,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Specifies if pressing escape key should hide the tooltip."
                         },
                         {
@@ -52268,7 +52268,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the tooltip should be hidden."
                         },
                         {
@@ -52276,7 +52276,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"focus\" | \"hover\"",
-                            "default": "```ts\nhover\n```",
+                            "default": "hover",
                             "description": "Event to show the tooltip."
                         },
                         {
@@ -52284,7 +52284,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to hide the tooltip in milliseconds."
                         },
                         {
@@ -52292,7 +52292,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseleave\n```",
+                            "default": "mouseleave",
                             "description": "Event to hide the tooltip if the event property is empty."
                         },
                         {
@@ -52300,7 +52300,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the tooltip will follow the mouse."
                         },
                         {
@@ -52308,7 +52308,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines left position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -52316,7 +52316,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines top position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -52332,7 +52332,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\" | \"mouse\"",
-                            "default": "```ts\nright\n```",
+                            "default": "right",
                             "description": "Position of the tooltip."
                         },
                         {
@@ -52340,7 +52340,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to show the tooltip in milliseconds."
                         },
                         {
@@ -52348,7 +52348,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseenter\n```",
+                            "default": "mouseenter",
                             "description": "Event to show the tooltip if the event property is empty."
                         },
                         {
@@ -52356,7 +52356,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show tooltip for disabled elements."
                         },
                         {
@@ -52372,7 +52372,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to update the tooltip in milliseconds."
                         },
                         {
@@ -52396,7 +52396,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         }
                     ]
@@ -52477,7 +52477,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the tooltip should be hidden."
                         },
                         {
@@ -52493,7 +52493,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\" | \"mouse\"",
-                            "default": "```ts\nright\n```",
+                            "default": "right",
                             "description": "Position of the tooltip."
                         },
                         {
@@ -52517,7 +52517,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"focus\" | \"hover\"",
-                            "default": "```ts\nhover\n```",
+                            "default": "hover",
                             "description": "Event to show the tooltip."
                         },
                         {
@@ -52525,7 +52525,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseenter\n```",
+                            "default": "mouseenter",
                             "description": "Event to show the tooltip if the event property is empty."
                         },
                         {
@@ -52533,7 +52533,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nmouseleave\n```",
+                            "default": "mouseleave",
                             "description": "Event to hide the tooltip if the event property is empty."
                         },
                         {
@@ -52541,7 +52541,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the tooltip will follow the mouse."
                         },
                         {
@@ -52549,7 +52549,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines top position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -52557,7 +52557,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Defines left position of the tooltip in relation to the mouse when the mouseTrack is enabled."
                         },
                         {
@@ -52565,7 +52565,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to show the tooltip in milliseconds."
                         },
                         {
@@ -52573,7 +52573,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to update the tooltip in milliseconds."
                         },
                         {
@@ -52581,7 +52581,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay to hide the tooltip in milliseconds."
                         },
                         {
@@ -52589,7 +52589,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to hide tooltip when hovering over tooltip content."
                         },
                         {
@@ -52597,7 +52597,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show tooltip for disabled elements."
                         }
                     ]
@@ -52742,7 +52742,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -52750,7 +52750,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Unique key to enable dragdrop functionality."
                         },
                         {
@@ -52758,7 +52758,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: TreeProps) => ReactNode)",
-                            "default": "```ts\nNo results found\n```",
+                            "default": "No results found",
                             "description": "Template to display when filtering does not return any results."
                         },
                         {
@@ -52782,7 +52782,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, displays an input field to filter the items."
                         },
                         {
@@ -52790,7 +52790,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -52798,7 +52798,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -52814,7 +52814,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -52822,7 +52822,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"strict\" | \"lenient\"",
-                            "default": "```ts\nlenient\n```",
+                            "default": "lenient",
                             "description": "Mode for filtering valid values are \"lenient\" and \"strict\". Default is lenient."
                         },
                         {
@@ -52878,7 +52878,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to display loading indicator."
                         },
                         {
@@ -52894,7 +52894,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines how multiple items can be selected, when true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -52902,7 +52902,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((node: TreeNode, options: TreeNodeTemplateOptions) => ReactNode)",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Template of node element."
                         },
                         {
@@ -52910,7 +52910,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether checkbox selections propagate to descendant nodes."
                         },
                         {
@@ -52918,7 +52918,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether checkbox selections propagate to ancestor nodes."
                         },
                         {
@@ -52958,7 +52958,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show the header or not."
                         },
                         {
@@ -52982,7 +52982,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -53924,7 +53924,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the node is droppable when dragdrop is enabled."
                         },
                         {
@@ -53932,7 +53932,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether the node is draggable when dragdrop is enabled."
                         },
                         {
@@ -54016,7 +54016,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -54040,7 +54040,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -54072,7 +54072,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should be disabled."
                         },
                         {
@@ -54080,7 +54080,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"comma\" | \"chip\"",
-                            "default": "```ts\ncomma\n```",
+                            "default": "comma",
                             "description": "Defines how the selected items are displayed, valid values are \"comma\" and \"chip\"."
                         },
                         {
@@ -54096,7 +54096,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: TreeSelectProps) => ReactNode)",
-                            "default": "```ts\nNo available options\n```",
+                            "default": "No available options",
                             "description": "Text to display when there is no data."
                         },
                         {
@@ -54112,7 +54112,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, displays an input field to filter the items."
                         },
                         {
@@ -54120,7 +54120,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nlabel\n```",
+                            "default": "label",
                             "description": "When filtering is enabled, filterBy decides which field or fields (comma separated) to search against."
                         },
                         {
@@ -54128,7 +54128,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -54144,7 +54144,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "When the panel is opened, it specifies that the filter input should focus automatically."
                         },
                         {
@@ -54152,7 +54152,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -54160,7 +54160,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"strict\" | \"lenient\"",
-                            "default": "```ts\nlenient\n```",
+                            "default": "lenient",
                             "description": "Mode for filtering valid values are \"lenient\" and \"strict\". Default is lenient."
                         },
                         {
@@ -54208,7 +54208,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -54216,7 +54216,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines how multiple items can be selected, when true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -54232,7 +54232,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((node: TreeNode, options: TreeNodeTemplateOptions) => ReactNode)",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Template of internally used tree component node element."
                         },
                         {
@@ -54312,7 +54312,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n400px\n```",
+                            "default": "400px",
                             "description": "Maximum height of the options panel."
                         },
                         {
@@ -54328,7 +54328,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, a clear icon is displayed to clear the value."
                         },
                         {
@@ -54368,7 +54368,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -54392,7 +54392,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -55199,7 +55199,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether to show it even there is only one page."
                         },
                         {
@@ -55231,7 +55231,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"expand\" | \"fit\"",
-                            "default": "```ts\nfit\n```",
+                            "default": "fit",
                             "description": "Defines whether the overall table width should change on column resize, valid values are \"fit\" and \"expand\"."
                         },
                         {
@@ -55247,7 +55247,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\n({currentPage} of {totalPages})\n```",
+                            "default": "({currentPage} of {totalPages})",
                             "description": "Template of the current page report element. Available placeholders are {currentPage}, {totalPages}, {rows}, {first}, {last} and {totalRecords}"
                         },
                         {
@@ -55255,7 +55255,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "0 | 1 | -1 | null",
-                            "default": "```ts\n1\n```",
+                            "default": "1",
                             "description": "Default sort order of an unsorted column."
                         },
                         {
@@ -55263,7 +55263,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "ReactNode | ((props: TreeTableProps) => ReactNode)",
-                            "default": "```ts\nNo results found\n```",
+                            "default": "No results found",
                             "description": "Text to display when there is no data."
                         },
                         {
@@ -55279,7 +55279,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n300\n```",
+                            "default": "300",
                             "description": "Delay in milliseconds before filtering the data."
                         },
                         {
@@ -55287,7 +55287,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "string",
-                            "default": "```ts\nundefined\n```",
+                            "default": "undefined",
                             "description": "Locale to use in filtering. The default locale is the host environment's current locale."
                         },
                         {
@@ -55295,7 +55295,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"strict\" | \"lenient\"",
-                            "default": "```ts\nlenient\n```",
+                            "default": "lenient",
                             "description": "Mode for filtering valid values are lenient and strict. Default is lenient."
                         },
                         {
@@ -55311,7 +55311,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the first row to be displayed."
                         },
                         {
@@ -55367,7 +55367,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"endsWith\" | \"startsWith\" | \"custom\" | \"contains\" | \"in\" | \"equals\" | \"notEquals\" | \"notContains\" | \"notIn\" | \"lt\" | \"lte\" | \"gt\" | \"gte\" | \"between\" | \"dateIs\" | \"dateIsNot\" | \"dateBefore\" | \"dateAfter\"",
-                            "default": "```ts\ncontains\n```",
+                            "default": "contains",
                             "description": "Defines filterMatchMode; \"startsWith\", \"contains\", \"endsWith\", \"equals\", \"notEquals\", \"in\", \"notIn\", \"lt\", \"lte\", \"gt\", \"gte\" and \"custom\"."
                         },
                         {
@@ -55399,7 +55399,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if data is loaded and interacted with in lazy manner."
                         },
                         {
@@ -55407,7 +55407,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Displays a loader to indicate data load is in progress."
                         },
                         {
@@ -55423,7 +55423,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Defines whether metaKey is requred or not for the selection. When true metaKey needs to be pressed to select or unselect an item and when set to false selection of each item can be toggled individually. On touch enabled devices, metaKeySelection is turned off automatically."
                         },
                         {
@@ -55439,7 +55439,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n5\n```",
+                            "default": "5",
                             "description": "Number of page links to display."
                         },
                         {
@@ -55447,7 +55447,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified as true, enables the pagination."
                         },
                         {
@@ -55463,7 +55463,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "HTMLElement | \"self\" | (() => HTMLElement) | null",
-                            "default": "```ts\ndocument.body\n```",
+                            "default": "document.body",
                             "description": "DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located."
                         },
                         {
@@ -55479,7 +55479,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"top\" | \"bottom\"",
-                            "default": "```ts\nbottom\n```",
+                            "default": "bottom",
                             "description": "Position of the paginator, options are \"top\",\"bottom\" or \"both\"."
                         },
                         {
@@ -55495,7 +55495,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "PaginatorTemplate",
-                            "default": "```ts\nFirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown\n```",
+                            "default": "FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown",
                             "description": "Template of the paginator. For details, refer to the template section of the paginator documentation for further options."
                         },
                         {
@@ -55503,7 +55503,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether checkbox selections propagate to descendant nodes."
                         },
                         {
@@ -55511,7 +55511,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Whether checkbox selections propagate to ancestor nodes."
                         },
                         {
@@ -55535,7 +55535,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can have an un-sorted state."
                         },
                         {
@@ -55543,7 +55543,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can be reordered using drag and drop."
                         },
                         {
@@ -55567,7 +55567,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, columns can be resized using drag and drop."
                         },
                         {
@@ -55575,7 +55575,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, background of the rows change on hover."
                         },
                         {
@@ -55599,7 +55599,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When specified, enables horizontal and/or vertical scrolling."
                         },
                         {
@@ -55631,7 +55631,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Determines whether the cell editor will be opened when clicking to select any row on Selection and Cell Edit modes."
                         },
                         {
@@ -55639,7 +55639,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show grid lines between cells."
                         },
                         {
@@ -55663,7 +55663,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"multiple\" | \"single\"",
-                            "default": "```ts\nsingle\n```",
+                            "default": "single",
                             "description": "Defines whether sorting works on single column or on multiple columns."
                         },
                         {
@@ -55687,7 +55687,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"custom\" | \"session\" | \"local\"",
-                            "default": "```ts\nsession\n```",
+                            "default": "session",
                             "description": "Defines where a stateful table keeps its state, valid values are \"session\" for sessionStorage, \"local\" for localStorage and \"custom\"."
                         },
                         {
@@ -55695,7 +55695,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to displays rows with alternating colors."
                         },
                         {
@@ -55751,7 +55751,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -56962,7 +56962,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should automatically get focus on load."
                         },
                         {
@@ -56986,7 +56986,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the element value cannot be altered."
                         },
                         {
@@ -56994,7 +56994,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the component should have invalid state style."
                         },
                         {
@@ -57018,7 +57018,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When present, it specifies that the value cannot be changed."
                         },
                         {
@@ -57050,7 +57050,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
                         },
                         {
@@ -57066,7 +57066,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"filled\" | \"outlined\"",
-                            "default": "```ts\noutlined\n```",
+                            "default": "outlined",
                             "description": "Specifies the input variant of the component."
                         }
                     ]
@@ -57558,7 +57558,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Used to append each loaded item to top without removing any items from the DOM. Using very large data may cause the browser to crash."
                         },
                         {
@@ -57566,7 +57566,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to dynamically change the height or width of scrollable container."
                         },
                         {
@@ -57606,7 +57606,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Delay in scroll before new data is loaded."
                         },
                         {
@@ -57614,7 +57614,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "If disabled, the VirtualScroller feature is eliminated and the content is displayed directly."
                         },
                         {
@@ -57630,7 +57630,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "When enabled, positions the content as inline."
                         },
                         {
@@ -57662,7 +57662,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Defines if data is loaded and interacted with in lazy manner."
                         },
                         {
@@ -57670,7 +57670,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Used to implement a custom loader instead of using the loader feature in the VirtualScroller."
                         },
                         {
@@ -57687,7 +57687,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether the data is loaded."
                         },
                         {
@@ -57719,7 +57719,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "\"both\" | \"horizontal\" | \"vertical\"",
-                            "default": "```ts\n'vertical'\n```",
+                            "default": "'vertical'",
                             "description": "The orientation of scrollbar, valid values are 'vertical', 'horizontal' and 'both'."
                         },
                         {
@@ -57743,7 +57743,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n10\n```",
+                            "default": "10",
                             "description": "Delay after window's resize finishes."
                         },
                         {
@@ -57767,7 +57767,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\nfalse\n```",
+                            "default": "false",
                             "description": "Whether to show loader."
                         },
                         {
@@ -57775,7 +57775,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "```ts\ntrue\n```",
+                            "default": "true",
                             "description": "Used to implement a custom spacer instead of using the spacer feature in the VirtualScroller."
                         },
                         {
@@ -57783,7 +57783,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Used to specify how many items to load in each load method in lazy mode."
                         },
                         {
@@ -57799,7 +57799,7 @@
                             "optional": true,
                             "readonly": false,
                             "type": "number",
-                            "default": "```ts\n0\n```",
+                            "default": "0",
                             "description": "Index of the element in tabbing order."
                         }
                     ]

--- a/components/doc/common/docapitable.js
+++ b/components/doc/common/docapitable.js
@@ -78,6 +78,10 @@ const DocApiTable = (props) => {
             );
         };
 
+        const formatDefaultValue = (value) => {
+            return typeof value === 'string' ? value.replace(/^```[^\r\n]*\r?\n([\s\S]*?)\r?\n```$/, '$1') : value;
+        };
+
         const createTBody = () => {
             return (
                 <React.Fragment>
@@ -114,7 +118,7 @@ const DocApiTable = (props) => {
                                                     })
                                                 ) : k === 'default' ? (
                                                     <div className={classNames('doc-option-default', { 'doc-option-dark': appContentContext.darkMode, 'doc-option-light': !appContentContext.darkMode })}>
-                                                        {ObjectUtils.isEmpty(v) ? 'null' : createContent(v, k === 'name', d.deprecated)}
+                                                        {ObjectUtils.isEmpty(v) ? 'null' : createContent(formatDefaultValue(v), k === 'name', d.deprecated)}
                                                     </div>
                                                 ) : k === 'type' ? (
                                                     <span className="doc-option-type">{createContent(v, k === 'name', d.deprecated)}</span>


### PR DESCRIPTION
## Summary
- normalize TypeDoc default-value fences in generated API docs and web-types
- defensively strip stale fenced defaults when rendering the docs table
- regenerate API documentation

Fixes #413

## Verification
- npm run build:api
- npm run build:docs
- ESLint on updated source files